### PR TITLE
allow upgrade of miniconda during install

### DIFF
--- a/installer/install.bash
+++ b/installer/install.bash
@@ -25,7 +25,7 @@ function install_miniconda {
         exit 1
     fi
 
-    bash ${INSTALLER_PATH} -b -p ${CONDA_DIR}
+    bash ${INSTALLER_PATH} -u -b -p ${CONDA_DIR}
 
     # Allow easy direct installs from conda forge
     ${CONDA_DIR}/bin/conda config --system --add channels conda-forge


### PR DESCRIPTION
closes #1 by adding the `-u` flag. I tested it on my VM and it still installs w/o existing `miniconda` installation and also works if there's an existing installation.