### PR TITLE
[wip] enable sudo-less install for admins

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,8 +39,7 @@ jobs:
     integration-test:
         machine: true
         environment:
-            cmd: "python3 .circleci/integration-test.py"
-            PATH: "$HOME/conda/bin:$PATH"
+            cmd: "/opt/conda/bin/python3 .circleci/integration-test.py"
         steps:
             # Download and cache dependencies
             - restore_cache:
@@ -51,13 +50,13 @@ jobs:
                 name: setup python3.6
                 command: |
                     if [[ ! -d "$HOME/conda" ]]; then
-                        curl -L https://repo.continuum.io/miniconda/Miniconda3-4.5.4-Linux-x86_64.sh > miniconda.sh
-                        bash miniconda.sh -b -p $HOME/conda
+                        curl -L https://repo.continuum.io/miniconda/Miniconda3-4.5.4-Linux-x86_64.sh > /tmp/miniconda.sh
+                        sudo bash /tmp/miniconda.sh -b -p /opt/conda
                     fi
 
             - save_cache:
                 paths:
-                    - $HOME/conda
+                    - /opt/conda
                 key: v1-integration-miniconda3-4.5.4
 
             - checkout
@@ -65,7 +64,7 @@ jobs:
             - run:
                 name: build systemd image
                 command: |
-                     $cmd build-image
+                    $cmd build-image
 
             - run:
                 name: start systemd image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,8 +39,27 @@ jobs:
     integration-test:
         machine: true
         environment:
-            cmd: "/usr/bin/python3 .circleci/integration-test.py"
+            cmd: "python3 .circleci/integration-test.py"
+            PATH: "$HOME/conda/bin:$PATH"
         steps:
+            # Download and cache dependencies
+            - restore_cache:
+                keys:
+                    - v1-integration-miniconda3-4.5.4
+
+            - run:
+                name: setup python3.6
+                command: |
+                    if [[ ! -d "$HOME/conda" ]]; then
+                        curl -L https://repo.continuum.io/miniconda/Miniconda3-4.5.4-Linux-x86_64.sh > miniconda.sh
+                        bash miniconda.sh -b -p $HOME/conda
+                    fi
+
+            - save_cache:
+                paths:
+                    - $HOME/conda
+                key: v1-integration-miniconda3-4.5.4
+
             - checkout
 
             - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,17 +37,15 @@ jobs:
                     codecov
 
     integration-test:
-        docker:
-            - image: docker:18.05.0-ce-git
+        machine: true
 
         steps:
             - run:
                 name: setup python3
                 command: |
-                    apk add --no-cache python3
+                    sudo apt-get -y install python3
 
             - checkout
-            - setup_remote_docker
 
             - run:
                 name: build systemd image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,46 +38,42 @@ jobs:
 
     integration-test:
         machine: true
-
+        environment:
+            cmd: "/usr/bin/python3 .circleci/integration-test.py"
         steps:
-            - run:
-                name: setup python3
-                command: |
-                    sudo apt-get -y install python3
-
             - checkout
 
             - run:
                 name: build systemd image
                 command: |
-                    python3 .circleci/integration-test.py build-image
+                     $cmd build-image
 
             - run:
                 name: start systemd image
                 command: |
-                    python3 .circleci/integration-test.py start-container
+                    $cmd start-container
 
             - run:
                 name: run tljh installer
                 command: |
-                    python3 .circleci/integration-test.py copy . /srv/src
-                    python3 .circleci/integration-test.py run 'python3 /srv/src/bootstrap/bootstrap.py'
+                    $cmd copy . /srv/src
+                    $cmd run 'python3 /srv/src/bootstrap/bootstrap.py'
 
             - run:
                 name: print systemd status + logs
                 command: |
-                    python3 .circleci/integration-test.py run 'journalctl --no-pager'
-                    python3 .circleci/integration-test.py run 'systemctl --no-pager status jupyterhub configurable-http-proxy'
+                    $cmd run 'journalctl --no-pager'
+                    $cmd run 'systemctl --no-pager status jupyterhub configurable-http-proxy'
 
             - run:
                 name: install integration test requirements
                 command: |
-                    python3 .circleci/integration-test.py run 'python3 -m pip install -r /srv/src/integration-tests/requirements.txt'
+                    $cmd run 'python3 -m pip install -r /srv/src/integration-tests/requirements.txt'
 
             - run:
                 name: run integration tests
                 command: |
-                    python3 .circleci/integration-test.py run 'python3 -m pytest -v /srv/src/integration-tests'
+                    $cmd run 'python3 -m pytest -v /srv/src/integration-tests'
 
 workflows:
     version: 2

--- a/bootstrap/bootstrap.py
+++ b/bootstrap/bootstrap.py
@@ -102,24 +102,24 @@ def pip_install(prefix, packages, editable=False):
 
 def main():
     install_prefix = os.environ.get('TLJH_INSTALL_PREFIX', '/opt/tljh')
-    hub_prefix = os.path.join(install_prefix, 'hub')
+    env_prefix = os.path.join(install_prefix, 'env')
     miniconda_version = '4.5.4'
     miniconda_installer_md5 = "a946ea1d0c4a642ddf0c3a26a18bb16d"
 
 
     if not os.path.isdir(install_prefix):
         print("Creating TLJH directory %s" % install_prefix)
-        os.makedirs(install_prefix, mode=0o771)
+        os.makedirs(install_prefix, mode=0o755)
     # set acl on install directory so that new files
     # inherit group-writable permissions
     subprocess.check_call(["setfacl", "-d", "-m", "g::rwX", install_prefix])
 
     print('Checking if TLJH is already installed...')
-    if not check_miniconda_version(hub_prefix, miniconda_version):
+    if not check_miniconda_version(env_prefix, miniconda_version):
         initial_setup = True
         print('Downloading & setting up hub environment...')
         with download_miniconda_installer(miniconda_version, miniconda_installer_md5) as installer_path:
-            install_miniconda(installer_path, hub_prefix)
+            install_miniconda(installer_path, env_prefix)
         print('Hub environment set up!')
     else:
         initial_setup = False
@@ -136,13 +136,13 @@ def main():
         'git+https://github.com/yuvipanda/the-littlest-jupyterhub.git'
     )
 
-    pip_install(hub_prefix, [tljh_repo_path], editable=is_dev)
+    pip_install(env_prefix, [tljh_repo_path], editable=is_dev)
 
     print('Starting TLJH installer...')
     os.execv(
-        os.path.join(hub_prefix, 'bin', 'python3'),
+        os.path.join(env_prefix, 'bin', 'python3'),
         [
-            os.path.join(hub_prefix, 'bin', 'python3'),
+            os.path.join(env_prefix, 'bin', 'python3'),
             '-m',
             'tljh.installer',
         ] + sys.argv[1:]

--- a/bootstrap/bootstrap.py
+++ b/bootstrap/bootstrap.py
@@ -103,6 +103,14 @@ def main():
     miniconda_version = '4.5.4'
     miniconda_installer_md5 = "a946ea1d0c4a642ddf0c3a26a18bb16d"
 
+
+    if not os.path.isdir(install_prefix):
+        print("Creating TLJH directory %s" % install_prefix)
+        os.makedirs(install_prefix, mode=0o771)
+    # set acl on install directory so that new files
+    # inherit group-writable permissions
+    subprocess.check_call(["setfacl", "-d", "-m", "g::rwX", install_prefix])
+
     print('Checking if TLJH is already installed...')
     if not check_miniconda_version(hub_prefix, miniconda_version):
         initial_setup = True

--- a/bootstrap/bootstrap.py
+++ b/bootstrap/bootstrap.py
@@ -11,6 +11,7 @@ Constraints:
   - Be compatible with Python 3.4 (since we support Ubuntu 16.04)
   - Use stdlib modules only
 """
+from distutils.version import LooseVersion as V
 import os
 import subprocess
 import urllib.request
@@ -38,13 +39,15 @@ def check_miniconda_version(prefix, version):
     Return true if a miniconda install with version exists at prefix
     """
     try:
-        return subprocess.check_output([
+        installed_version = subprocess.check_output([
             os.path.join(prefix, 'bin', 'conda'),
             '-V'
-        ]).decode().strip() == 'conda {}'.format(version)
+        ]).decode().strip().split()[1]
     except (subprocess.CalledProcessError, FileNotFoundError):
         # Conda doesn't exist, or wrong version
         return False
+    else:
+        return V(installed_version) >= V(version)
 
 
 @contextlib.contextmanager

--- a/integration-tests/Dockerfile
+++ b/integration-tests/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:18.04
 
 RUN apt-get update --yes
 
-RUN apt-get install --yes systemd curl git
+RUN apt-get install --yes systemd curl git acl
 
 # Kill all the things we don't need
 RUN find /etc/systemd/system \

--- a/integration-tests/Dockerfile
+++ b/integration-tests/Dockerfile
@@ -23,6 +23,6 @@ STOPSIGNAL SIGRTMIN+3
 # Set up image to be useful out of the box for development & CI
 ENV TLJH_BOOTSTRAP_DEV=yes
 ENV TLJH_BOOTSTRAP_PIP_SPEC=/srv/src
-ENV PATH=/opt/tljh/hub/bin:${PATH}
+ENV PATH=/opt/tljh/env/bin:${PATH}
 
 CMD ["/bin/bash", "-c", "exec /sbin/init --log-target=journal 3>&1"]

--- a/integration-tests/test_install.py
+++ b/integration-tests/test_install.py
@@ -94,7 +94,6 @@ def permissions_test(group, path, *, readable=None, writable=None, dirs_only=Fal
         assert False, "\n".join(failures)
 
 
-@pytest.mark.parametrize("group, writable", [(ADMIN_GROUP, True), (USER_GROUP, False)])
 def test_admin_writable(group, writable):
     permissions_test(ADMIN_GROUP, sys.prefix, writable=True, dirs_only=True)
 

--- a/integration-tests/test_install.py
+++ b/integration-tests/test_install.py
@@ -1,0 +1,166 @@
+from contextlib import contextmanager
+from concurrent.futures import ProcessPoolExecutor
+from functools import partial
+import grp
+import os
+import pwd
+import subprocess
+import sys
+import tempfile
+
+import pytest
+
+
+ADMIN_GROUP = "jupyterhub-admins"
+USER_GROUP = "jupyterhub-users"
+INSTALL_PREFIX = os.environ.get("TLJH_INSTALL_PREFIX", "/opt/tljh")
+
+
+@contextmanager
+def noop():
+    """no-op context manager
+
+    for parametrized tests
+    """
+    yield
+
+
+def setgroup(group):
+    """Become the user nobody:group
+
+    Only call in a subprocess because there's no turning back
+    """
+    gid = grp.getgrnam(group).gr_gid
+    uid = pwd.getpwnam("nobody").pw_uid
+    os.setgid(gid)
+    os.setuid(uid)
+    os.environ["HOME"] = "/tmp/test-home-%i-%i" % (uid, gid)
+
+
+@pytest.mark.parametrize("group", [ADMIN_GROUP, USER_GROUP])
+def test_groups_exist(group):
+    """Verify that groups exist"""
+    grp.getgrnam(group)
+
+
+def permissions_test(group, path, *, readable=None, writable=None, dirs_only=False):
+    """Run a permissions test on all files in a path path"""
+    # start a subprocess and become nobody:group in the process
+    pool = ProcessPoolExecutor(1)
+    pool.submit(setgroup, group)
+
+    def access(path, flag):
+        """Run access test in subproccess as nobody:group"""
+        return pool.submit(os.access, path, flag).result()
+
+    total_tested = 0
+
+    failures = []
+
+    # walk the directory and check permissions
+    for root, dirs, files in os.walk(path):
+        to_test = dirs
+        if not dirs_only:
+            to_test += files
+        total_tested += len(to_test)
+        for name in to_test:
+            path = os.path.join(root, name)
+            if os.path.islink(path):
+                # skip links
+                continue
+
+            # check if the path should be writable
+            if writable is not None:
+                if access(path, os.W_OK) != writable:
+                    failures.append(
+                        "{} should {}be writable by {}".format(
+                            path, "" if writable else "not ", group
+                        )
+                    )
+
+            # check if the path should be readable
+            if readable is not None:
+                if access(path, os.R_OK) != readable:
+                    failures.append(
+                        "{} should {}be readable by {}".format(
+                            path, "" if readable else "not ", group
+                        )
+                    )
+    # verify that we actually tested some files
+    # (path typos)
+    assert total_tested > 0, "No files to test in %r" % path
+    # raise a nice summary of the failures:
+    if failures:
+        assert False, "\n".join(failures)
+
+
+@pytest.mark.parametrize("group, writable", [(ADMIN_GROUP, True), (USER_GROUP, False)])
+def test_admin_writable(group, writable):
+    permissions_test(ADMIN_GROUP, sys.prefix, writable=True, dirs_only=True)
+
+
+@pytest.mark.parametrize("group", [ADMIN_GROUP, USER_GROUP])
+def test_all_readable(group):
+    # every file in sys.prefix should be readable by everyone
+    permissions_test(group, sys.prefix, readable=True)
+
+
+@pytest.mark.parametrize(
+    "group, readwrite", [(ADMIN_GROUP, False), (USER_GROUP, False)]
+)
+def test_state_permissions(group, readwrite):
+    state_dir = os.path.abspath(os.path.join(sys.prefix, os.pardir, "state"))
+    permissions_test(group, state_dir, writable=readwrite, readable=readwrite)
+
+
+@pytest.mark.parametrize("group, allowed", [(USER_GROUP, False), (ADMIN_GROUP, True)])
+def test_pip_install(group, allowed):
+    if allowed:
+        context = noop()
+    else:
+        context = pytest.raises(subprocess.CalledProcessError)
+
+    with context:
+        subprocess.check_call(
+            [
+                sys.executable,
+                "-m",
+                "pip",
+                "install",
+                "--ignore-installed",
+                "--no-deps",
+                "flit",
+            ],
+            preexec_fn=partial(setgroup, group),
+        )
+    if allowed:
+        subprocess.check_call(
+            [sys.executable, "-m", "pip", "uninstall", "-y", "flit"],
+            preexec_fn=partial(setgroup, group),
+        )
+
+
+@pytest.mark.parametrize("group, allowed", [(USER_GROUP, False), (ADMIN_GROUP, True)])
+def test_pip_upgrade(group, allowed):
+    if allowed:
+        context = noop()
+    else:
+        context = pytest.raises(subprocess.CalledProcessError)
+    with context:
+        subprocess.check_call(
+            [
+                sys.executable,
+                "-m",
+                "pip",
+                "install",
+                "--ignore-installed",
+                "--no-deps",
+                "testpath==0.3.0",
+            ],
+            preexec_fn=partial(setgroup, group),
+        )
+    if allowed:
+        subprocess.check_call(
+            [sys.executable, "-m", "pip", "install", "--upgrade", "testpath"],
+            preexec_fn=partial(setgroup, group),
+        )

--- a/tljh/installer.py
+++ b/tljh/installer.py
@@ -11,11 +11,11 @@ import time
 from ruamel.yaml import YAML
 
 INSTALL_PREFIX = os.environ.get('TLJH_INSTALL_PREFIX', '/opt/tljh')
-HUB_ENV_PREFIX = os.path.join(INSTALL_PREFIX, 'hub')
+HUB_ENV_PREFIX = os.path.join(INSTALL_PREFIX, 'env')
 # users and hub in the same env:
 USER_ENV_PREFIX = HUB_ENV_PREFIX
 
-STATE_DIR = os.path.join(HUB_ENV_PREFIX, 'state')
+STATE_DIR = os.path.join(INSTALL_PREFIX, 'state')
 
 HERE = os.path.abspath(os.path.dirname(__file__))
 
@@ -104,7 +104,7 @@ def ensure_usergroups():
             HUB_ENV_PREFIX
         )
     )
-    user.ensure_group_permissions("jupyterhub-admins", INSTALL_PREFIX)
+    user.ensure_group_permissions("jupyterhub-admins", HUB_ENV_PREFIX)
 
 
 def ensure_user_environment():

--- a/tljh/installer.py
+++ b/tljh/installer.py
@@ -102,6 +102,7 @@ def ensure_user_environment():
     """
     print("Setting up user environment...")
     conda.ensure_conda_env(USER_ENV_PREFIX)
+    user.ensure_group_permissions("jupyterhub-admins", USER_ENV_PREFIX)
     conda.ensure_conda_packages(USER_ENV_PREFIX, [
         # Conda's latest version is on conda much more so than on PyPI.
         'conda==4.5.8'

--- a/tljh/installer.py
+++ b/tljh/installer.py
@@ -40,10 +40,10 @@ def ensure_jupyterhub_service(prefix):
     systemd.reload_daemon()
 
     # Set up proxy / hub secret oken if it is not already setup
-    # FIXME: Check umask here properly
     proxy_secret_path = os.path.join(INSTALL_PREFIX, 'configurable-http-proxy.secret')
     if not os.path.exists(proxy_secret_path):
         with open(proxy_secret_path, 'w') as f:
+            os.fchmod(f.fileno(), 0o700)
             f.write('CONFIGPROXY_AUTH_TOKEN=' + secrets.token_hex(32))
         # If we are changing CONFIGPROXY_AUTH_TOKEN, restart configurable-http-proxy!
         systemd.restart_service('configurable-http-proxy')

--- a/tljh/installer.py
+++ b/tljh/installer.py
@@ -15,6 +15,8 @@ HUB_ENV_PREFIX = os.path.join(INSTALL_PREFIX, 'hub')
 # users and hub in the same env:
 USER_ENV_PREFIX = HUB_ENV_PREFIX
 
+STATE_DIR = os.path.join(HUB_ENV_PREFIX, 'state')
+
 HERE = os.path.abspath(os.path.dirname(__file__))
 
 rt_yaml = YAML()
@@ -39,8 +41,10 @@ def ensure_jupyterhub_service(prefix):
     systemd.install_unit('jupyterhub.service', hub_unit_template.format(**unit_params))
     systemd.reload_daemon()
 
+    os.makedirs(STATE_DIR, mode=0o700, exist_ok=True)
+
     # Set up proxy / hub secret oken if it is not already setup
-    proxy_secret_path = os.path.join(INSTALL_PREFIX, 'configurable-http-proxy.secret')
+    proxy_secret_path = os.path.join(STATE_DIR, 'configurable-http-proxy.secret')
     if not os.path.exists(proxy_secret_path):
         with open(proxy_secret_path, 'w') as f:
             os.fchmod(f.fileno(), 0o700)
@@ -48,7 +52,6 @@ def ensure_jupyterhub_service(prefix):
         # If we are changing CONFIGPROXY_AUTH_TOKEN, restart configurable-http-proxy!
         systemd.restart_service('configurable-http-proxy')
 
-    os.makedirs(os.path.join(INSTALL_PREFIX, 'hub', 'state'), mode=0o700, exist_ok=True)
     # Start CHP if it has already not been started
     systemd.start_service('configurable-http-proxy')
     # If JupyterHub is running, we want to restart it.

--- a/tljh/installer.py
+++ b/tljh/installer.py
@@ -12,7 +12,8 @@ from ruamel.yaml import YAML
 
 INSTALL_PREFIX = os.environ.get('TLJH_INSTALL_PREFIX', '/opt/tljh')
 HUB_ENV_PREFIX = os.path.join(INSTALL_PREFIX, 'hub')
-USER_ENV_PREFIX = os.path.join(INSTALL_PREFIX, 'user')
+# users and hub in the same env:
+USER_ENV_PREFIX = HUB_ENV_PREFIX
 
 HERE = os.path.abspath(os.path.dirname(__file__))
 
@@ -95,6 +96,13 @@ def ensure_usergroups():
         # `pip` is in the $PATH we set in jupyterhub_config.py to include the user conda env.
         f.write('Defaults exempt_group = jupyterhub-admins\n')
 
+    print(
+        "Granting write permission for {} to JupyterHub admins".format(
+            HUB_ENV_PREFIX
+        )
+    )
+    user.ensure_group_permissions("jupyterhub-admins", INSTALL_PREFIX)
+
 
 def ensure_user_environment():
     """
@@ -102,15 +110,13 @@ def ensure_user_environment():
     """
     print("Setting up user environment...")
     conda.ensure_conda_env(USER_ENV_PREFIX)
-    user.ensure_group_permissions("jupyterhub-admins", USER_ENV_PREFIX)
     conda.ensure_conda_packages(USER_ENV_PREFIX, [
         # Conda's latest version is on conda much more so than on PyPI.
         'conda==4.5.8'
     ])
 
     conda.ensure_pip_packages(USER_ENV_PREFIX, [
-        # JupyterHub + notebook package are base requirements for user environment
-        'jupyterhub==0.9.0',
+        # notebook package for users
         'notebook==5.5.0',
         # Install additional notebook frontends!
         'jupyterlab==0.32.1',

--- a/tljh/systemd-units/configurable-http-proxy.service
+++ b/tljh/systemd-units/configurable-http-proxy.service
@@ -14,10 +14,10 @@ PrivateTmp=yes
 PrivateDevices=yes
 ProtectKernelTunables=yes
 ProtectKernelModules=yes
-EnvironmentFile={install_prefix}/hub/state/configurable-http-proxy.secret
+EnvironmentFile={install_prefix}/state/configurable-http-proxy.secret
 # Set PATH so env can find correct node
-Environment=PATH=$PATH:{install_prefix}/hub/bin
-ExecStart={install_prefix}/hub/bin/configurable-http-proxy \
+Environment=PATH=$PATH:{install_prefix}/env/bin
+ExecStart={install_prefix}/env/bin/configurable-http-proxy \
             --ip 0.0.0.0 \
             --port 80 \
             --api-ip 127.0.0.1 \

--- a/tljh/systemd-units/configurable-http-proxy.service
+++ b/tljh/systemd-units/configurable-http-proxy.service
@@ -14,7 +14,7 @@ PrivateTmp=yes
 PrivateDevices=yes
 ProtectKernelTunables=yes
 ProtectKernelModules=yes
-EnvironmentFile={install_prefix}/configurable-http-proxy.secret
+EnvironmentFile={install_prefix}/hub/state/configurable-http-proxy.secret
 # Set PATH so env can find correct node
 Environment=PATH=$PATH:{install_prefix}/hub/bin
 ExecStart={install_prefix}/hub/bin/configurable-http-proxy \

--- a/tljh/systemd-units/jupyterhub.service
+++ b/tljh/systemd-units/jupyterhub.service
@@ -10,14 +10,14 @@ User=root
 Restart=always
 # jupyterhub process should have no access to home directories
 ProtectHome=tmpfs
-WorkingDirectory={install_prefix}/hub/state
+WorkingDirectory={install_prefix}/state
 # Protect bits that are normally shared across the system
 PrivateTmp=yes
 PrivateDevices=yes
 ProtectKernelTunables=yes
 ProtectKernelModules=yes
 # Source CONFIGPROXY_AUTH_TOKEN from here!
-EnvironmentFile={install_prefix}/hub/state/configurable-http-proxy.secret
+EnvironmentFile={install_prefix}/state/configurable-http-proxy.secret
 Environment=TLJH_INSTALL_PREFIX={install_prefix}
 ExecStart={python_interpreter_path} -m jupyterhub.app -f {jupyterhub_config_path}
 

--- a/tljh/systemd-units/jupyterhub.service
+++ b/tljh/systemd-units/jupyterhub.service
@@ -17,7 +17,7 @@ PrivateDevices=yes
 ProtectKernelTunables=yes
 ProtectKernelModules=yes
 # Source CONFIGPROXY_AUTH_TOKEN from here!
-EnvironmentFile={install_prefix}/configurable-http-proxy.secret
+EnvironmentFile={install_prefix}/hub/state/configurable-http-proxy.secret
 Environment=TLJH_INSTALL_PREFIX={install_prefix}
 ExecStart={python_interpreter_path} -m jupyterhub.app -f {jupyterhub_config_path}
 

--- a/tljh/user.py
+++ b/tljh/user.py
@@ -149,13 +149,10 @@ def ensure_group_permissions(groupname, path):
 
     - all files are owned by groupname
     - setgid bit so new files are owned by groupname by default
-    - setfacl so new files are group-writable by default
     """
 
     gid = grp.getgrnam(groupname).gr_gid
     _ensure_group_owner(gid, path, isdir=True)
-    # setfacl on the root so new files are group-writable
-    subprocess.check_call(["setfacl", "-d", "-m", "g::rwX", path])
     # recursively check permissions to make sure it's in the initial right state
     for root, dirs, files in os.walk(path):
         for d in dirs:

--- a/tljh/user.py
+++ b/tljh/user.py
@@ -111,11 +111,23 @@ def remove_user_group(username, groupname):
 
 def _ensure_group_owner(gid, path, *, isdir):
     """Ensure a file or directory is owned by a group"""
-    st = os.stat(path)
+
+    # check and update owner group
+    st = os.lstat(path)
     if st.st_gid != gid:
         # ensure owned by gid
-        os.chown(path, st.st_uid, gid)
-    correct_mode = current_mode = os.stat(path).st_mode
+        os.chown(path, st.st_uid, gid, follow_symlinks=False)
+
+    # check and update permissions
+    if os.chmod not in os.supports_follow_symlinks:
+        follow_symlinks = True
+        if os.path.islink(path):
+            # can't chmod symlinks on e.g. linux
+            return
+    else:
+        follow_symlinks = False
+
+    correct_mode = current_mode = os.lstat(path).st_mode
     if isdir:
         # setgid bit on directories so new files have the right group
         # all directories should have srwX permissions
@@ -129,7 +141,7 @@ def _ensure_group_owner(gid, path, *, isdir):
 
     # if mode is not correct, change it
     if correct_mode != current_mode:
-        os.chmod(path, correct_mode)
+        os.chmod(path, correct_mode, follow_symlinks=follow_symlinks)
 
 
 def ensure_group_permissions(groupname, path):


### PR DESCRIPTION
Goal: members of jupyterhub-admins should be able to install and upgrade packages without sudo.

The main change is using `setfacl` and `setgid` on the top-level directory to ensure that new files and directories in the env are owned by `jupyterhub-admins` and group-writable.

Changes:

- merge hub and user env in `/opt/tljh/env`
- move state out of env to `/opt/tljh/state`
- integration tests for permissions:
  - everyone can read every file in the env
  - admins can write any directory
  - neither admins nor users can read or write to state
  - admins can pip install/upgrade
  - users cannot pip install/upgrade

Somewhat unrelated fixes along the way:

- allow conda to be upgraded (fix == version check instead of >= check)

Some weirdnesses:

Not all *files* are group-writable. This is because of the behavior of pip and conda installers, which can make files read-only and/or not group-owned. This is okay for our purposes, because installation/upgrade should never involve *modification* of files, only removal of files and writing of new files. That means that only write-permission on directories is required. Sudo remains available if individual files want to be modified, which should be a rare, advanced use case.