### PR TITLE
Use a venv to run unit tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
             - run:
                 name: install python
                 command: |
-                    apt-get update --yes && apt-get install --yes python3 python3-pip
+                    apt-get update --yes && apt-get install --yes python3 python3-venv
 
             # Download and cache dependencies
             - restore_cache:
@@ -23,25 +23,30 @@ jobs:
                     - v1-dependencies-py3.6-
 
             - run:
+                name: Setup venv
+                command: |
+                    python3 -m venv /srv/venv
+
+            - run:
                 name: install dependencies
                 command: |
-                    pip3 install -r dev-requirements.txt
-                    pip3 install -e .
+                    /srv/venv/bin/pip install -r dev-requirements.txt
+                    /srv/venv/bin/pip install -e .
 
             - save_cache:
                 paths:
-                    - /usr/local/lib/python3.6
+                    - /srv/venv/
                 key: v1-dependencies-py3.6-{{ checksum "setup.py" }}-{{ checksum "dev-requirements.txt" }}
 
             - run:
                 name: run unit tests
                 command: |
-                    py.test --cov=tljh tests/
+                    /srv/venv/bin/py.test --cov=tljh tests/
 
             - run:
                 name: upload code coverage stats
                 command: |
-                    codecov
+                    /srv/venv/bin/codecov
 
     integration-test:
         docker:


### PR DESCRIPTION
- Can cache entire venv directory. When installing with system
  pip3, /usr/local/bin/ also needs caching - maybe other
  places too!
- Matches how the installer does things more closely

This should fix broken tests