### PR TITLE
Load arbitrary .py config files from a conf.d dir

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -83,6 +83,7 @@ Topic guides provide in-depth explanations of specific topics.
    topic/installer-actions
    topic/tljh-config
    topic/authenticator-configuration
+   topic/escape-hatch
 
 
 Troubleshooting

--- a/docs/topic/escape-hatch.rst
+++ b/docs/topic/escape-hatch.rst
@@ -7,10 +7,11 @@ Custom ``jupyterhub_config.py`` snippets
 Sometimes you need to customize TLJH in ways that are not officially supported.
 We provide an easy escape hatch for those cases with a ``jupyterhub_conf.d``
 directory that lets you load multiple ``jupyterhub_config.py`` snippets for
-your configuration.
+your configuration. You need to create the directory when you use it for
+the first time.
 
 Any files in ``/opt/tljh/jupyterhub_config.d`` that end in ``.py`` will be
 loaded in alphabetical order as python files to provide configuration for
 JupyterHub. Any config that can go in a regular ``jupyterhub_config.py``
 file is valid in these files. They will be loaded *after* any of the config
-options specified by TLJH are loaded.
+options specified with ``tljh-config`` are loaded.

--- a/docs/topic/escape-hatch.rst
+++ b/docs/topic/escape-hatch.rst
@@ -1,0 +1,16 @@
+.. _topic/escape-hatch:
+
+========================================
+Custom ``jupyterhub_config.py`` snippets
+========================================
+
+Sometimes you need to customize TLJH in ways that are not officially supported.
+We provide an easy escape hatch for those cases with a ``jupyterhub_conf.d``
+directory that lets you load multiple ``jupyterhub_config.py`` snippets for
+your configuration.
+
+Any files in ``/opt/tljh/jupyterhub_config.d`` that end in ``.py`` will be
+loaded in alphabetical order as python files to provide configuration for
+JupyterHub. Any config that can go in a regular ``jupyterhub_config.py``
+file is valid in these files. They will be loaded *after* any of the config
+options specified by TLJH are loaded.

--- a/tljh/jupyterhub_config.py
+++ b/tljh/jupyterhub_config.py
@@ -3,8 +3,8 @@ JupyterHub config for the littlest jupyterhub.
 """
 import copy
 import os
-
 import yaml
+from glob import glob
 
 from systemdspawner import SystemdSpawner
 from tljh import user, configurer
@@ -47,3 +47,9 @@ if os.path.exists(config_overrides_path):
 else:
     config_overrides = {}
 configurer.apply_config(config_overrides, c)
+
+# Load arbitrary .py config files if they exist.
+# This is our escape hatch
+extra_configs = sorted(glob(os.path.join(INSTALL_PREFIX, 'config.d', '*.py')))
+for ec in extra_configs:
+    load_subconfig(ec)

--- a/tljh/jupyterhub_config.py
+++ b/tljh/jupyterhub_config.py
@@ -50,6 +50,6 @@ configurer.apply_config(config_overrides, c)
 
 # Load arbitrary .py config files if they exist.
 # This is our escape hatch
-extra_configs = sorted(glob(os.path.join(INSTALL_PREFIX, 'config.d', '*.py')))
+extra_configs = sorted(glob(os.path.join(INSTALL_PREFIX, 'jupyterhub_config.d', '*.py')))
 for ec in extra_configs:
     load_subconfig(ec)


### PR DESCRIPTION
We want to keep the amount of custom code we support extremely
small. This provides a nice escape hatch for everything else.

- [x] Add documentation on how to use this
- [x] Add a test for this