### PR TITLE
Fix traefik config reload

### DIFF
--- a/tljh/config.py
+++ b/tljh/config.py
@@ -15,7 +15,7 @@ import sys
 import argparse
 from ruamel.yaml import YAML
 from copy import deepcopy
-from tljh import systemd
+from tljh import systemd, traefik
 
 
 yaml = YAML(typ='rt')
@@ -156,6 +156,8 @@ def reload_component(component):
         # FIXME: Verify hub is back up?
         print('Hub reload with new configuration complete')
     elif component == 'proxy':
+        # FIXME: How to set path here?
+        traefik.ensure_traefik_config('/opt/tljh/hub/state')
         systemd.restart_service('configurable-http-proxy')
         systemd.restart_service('traefik')
         print('Proxy reload with new configuration complete')

--- a/tljh/config.py
+++ b/tljh/config.py
@@ -17,7 +17,6 @@ import sys
 import argparse
 from ruamel.yaml import YAML
 from copy import deepcopy
-from tljh import systemd, traefik
 
 
 INSTALL_PREFIX = os.environ.get('TLJH_INSTALL_PREFIX', '/opt/tljh')
@@ -160,6 +159,8 @@ def reload_component(component):
 
     component can be 'hub' or 'proxy'.
     """
+    # import here to avoid circular imports
+    from tljh import systemd, traefik
     if component == 'hub':
         systemd.restart_service('jupyterhub')
         # FIXME: Verify hub is back up?

--- a/tljh/config.py
+++ b/tljh/config.py
@@ -11,11 +11,20 @@ tljh-config show firstlevel
 
 tljh-config show firstlevel.second_level
 """
+
+import os
 import sys
 import argparse
 from ruamel.yaml import YAML
 from copy import deepcopy
 from tljh import systemd, traefik
+
+
+INSTALL_PREFIX = os.environ.get('TLJH_INSTALL_PREFIX', '/opt/tljh')
+HUB_ENV_PREFIX = os.path.join(INSTALL_PREFIX, 'hub')
+USER_ENV_PREFIX = os.path.join(INSTALL_PREFIX, 'user')
+STATE_DIR = os.path.join(INSTALL_PREFIX, 'state')
+CONFIG_FILE = os.path.join(INSTALL_PREFIX, 'config.yaml')
 
 
 yaml = YAML(typ='rt')
@@ -28,7 +37,7 @@ def set_item_in_config(config, property_path, value):
     config is not mutated.
 
     property_path is a series of dot separated values. Any part of the path
-    that does not exist is created. 
+    that does not exist is created.
     """
     path_components = property_path.split('.')
 
@@ -156,8 +165,7 @@ def reload_component(component):
         # FIXME: Verify hub is back up?
         print('Hub reload with new configuration complete')
     elif component == 'proxy':
-        # FIXME: How to set path here?
-        traefik.ensure_traefik_config('/opt/tljh/hub/state')
+        traefik.ensure_traefik_config(STATE_DIR)
         systemd.restart_service('configurable-http-proxy')
         systemd.restart_service('traefik')
         print('Proxy reload with new configuration complete')

--- a/tljh/configurer.py
+++ b/tljh/configurer.py
@@ -11,8 +11,7 @@ FIXME: A strong feeling that JSON Schema should be involved somehow.
 import os
 import yaml
 
-INSTALL_PREFIX = os.environ.get('TLJH_INSTALL_PREFIX', '/opt/tljh')
-CONFIG_FILE = os.path.join(INSTALL_PREFIX, 'config.yaml')
+from tljh.config import CONFIG_FILE
 
 # Default configuration for tljh
 # User provided config is merged into this

--- a/tljh/installer.py
+++ b/tljh/installer.py
@@ -11,11 +11,7 @@ from urllib.request import urlopen, URLError
 from ruamel.yaml import YAML
 
 from tljh import conda, systemd, traefik, user, apt
-
-INSTALL_PREFIX = os.environ.get('TLJH_INSTALL_PREFIX', '/opt/tljh')
-HUB_ENV_PREFIX = os.path.join(INSTALL_PREFIX, 'hub')
-USER_ENV_PREFIX = os.path.join(INSTALL_PREFIX, 'user')
-STATE_DIR = os.path.join(INSTALL_PREFIX, 'state')
+from tljh.config import INSTALL_PREFIX, HUB_ENV_PREFIX, USER_ENV_PREFIX, STATE_DIR
 
 HERE = os.path.abspath(os.path.dirname(__file__))
 

--- a/tljh/jupyterhub_config.py
+++ b/tljh/jupyterhub_config.py
@@ -1,14 +1,14 @@
 """
 JupyterHub config for the littlest jupyterhub.
 """
+import copy
 import os
+
+import yaml
+
 from systemdspawner import SystemdSpawner
 from tljh import user, configurer
-import yaml
-import copy
-
-INSTALL_PREFIX = os.environ.get('TLJH_INSTALL_PREFIX')
-USER_ENV_PREFIX = os.path.join(INSTALL_PREFIX, 'user')
+from tljh.config import INSTALL_PREFIX, USER_ENV_PREFIX
 
 
 class CustomSpawner(SystemdSpawner):


### PR DESCRIPTION
Simply reloading traefik is not enough - we need to actually
write the new traefik.toml file.