### PR TITLE
fix coverage uploads

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
             - run:
                 name: install python
                 command: |
-                    apt-get update --yes && apt-get install --yes python3 python3-venv
+                    apt-get update --yes && apt-get install --yes python3 python3-venv git
 
             # Download and cache dependencies
             - restore_cache:
@@ -26,12 +26,13 @@ jobs:
                 name: Setup venv
                 command: |
                     python3 -m venv /srv/venv
+                    echo 'export PATH=/srv/venv/bin:$PATH' >> $BASH_ENV
 
             - run:
                 name: install dependencies
                 command: |
-                    /srv/venv/bin/pip install -r dev-requirements.txt
-                    /srv/venv/bin/pip install -e .
+                    pip install -r dev-requirements.txt
+                    pip install -e .
 
             - save_cache:
                 paths:
@@ -41,12 +42,12 @@ jobs:
             - run:
                 name: run unit tests
                 command: |
-                    /srv/venv/bin/py.test --cov=tljh tests/
+                    py.test --cov=tljh tests/
 
             - run:
                 name: upload code coverage stats
                 command: |
-                    /srv/venv/bin/codecov
+                    codecov
 
     integration-test:
         docker:


### PR DESCRIPTION
codecov upload has been failing since #72. I think because `coverage` is not installed on $PATH. <del>Activating the env should fix it, but will wait for CI to confirm.</del> It works. Had to use a bizarre `echo export >> $BASH_ENV ` snippet because [circleci doesn't support setting standard environment variables](https://circleci.com/docs/2.0/env-vars/#using-bash_env-to-set-environment-variables).