### PR TITLE
Remove readthedocs.yml file

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,6 +1,0 @@
-name: the-littlest-jupyterhub
-type: sphinx
-conda:
-    file: docs/environment.yml
-python:
-  version: 3


### PR DESCRIPTION
Fixes build for now, hopefully. Venv is configured via
the web interface



 <!-- Read more about our code-review guidelines at https://the-littlest-jupyterhub.readthedocs.io/en/latest/contributing/code-review.html -->