### PR TITLE
[WIP] adding uninstallation script

### DIFF
--- a/tljh/config.py
+++ b/tljh/config.py
@@ -192,6 +192,21 @@ def reload_component(component):
         print('Proxy reload with new configuration complete')
 
 
+def uninstall_tljh(confirm):
+    """Uninstall TLJH entirely from a machine."""
+    if confirm is False:
+        print('To confirm that you wish to uninstall JupyterHub entirely, '
+              're-run this command with the text "confirm", like so: \n\n'
+              '     tljh-config uninstall confirm')
+        return
+
+    # Uninstall all JupyterHub components
+    os.removedirs('/opt/tljh')
+    cmd = "curl https://raw.githubusercontent.com/jupyterhub/the-littlest-jupyterhub/master/bootstrap/bootstrap.py | sudo python3 - --admin <admin-user-name>"
+    print('JupyterHub has been removed. To re-install it, you may run the '
+          'following command:\n\n {}'.format(cmd))
+
+
 def parse_value(value_str):
     """Parse a value string"""
     if value_str is None:
@@ -285,6 +300,16 @@ def main(argv=None):
         nargs='?'
     )
 
+    uninstall_parser = subparsers.add_parser(
+        'uninstall',
+        help="Uninstall JupyterHub and delete all JupyterHub-related files"
+    )
+    uninstall_parser.add_argument(
+        'confirm',
+        help='Confirm that you really wish to uninstall JupyterHub entirely.',
+        default=False
+    )
+
     args = argparser.parse_args(argv)
 
     if args.action == 'show':
@@ -297,6 +322,8 @@ def main(argv=None):
         remove_config_value(args.config_path, args.key_path, parse_value(args.value))
     elif args.action == 'reload':
         reload_component(args.component)
+    elif args.action == 'uninstall':
+        uninstall_tljh(args.confirm)
     else:
         argparser.print_help()
 


### PR DESCRIPTION
 - [ ] Add / update documentation
 - [ ] Add tests

 This PR is meant to add an "uninstall" argument to the `tljh-config` tool. Here are some open questions:

1. Can it *really* delete everything without breaking itself in the middle of deleting things?
2. Can it delete the JupyterHub without really confusingly breaking someone's session if they're typing from a Jupyter Notebook server terminal (or jupyter lab).
3. Is the only thing we'd need to delete the `/opt/tljh` folder?
4. Should user directories be deleted by default

Depending on the answers to 1 and 2, I may or may not be +1 on this feature being added :-)

closes #128 if it's merged