### PR TITLE
Move tljh-config symlink to /usr/bin

### DIFF
--- a/docs/howto/admin/admin-users.rst
+++ b/docs/howto/admin/admin-users.rst
@@ -78,8 +78,8 @@ admin terminal:
 
 .. code-block:: bash
 
-   sudo -E tljh-config add-item users.admin <username>
-   sudo -E tljh-config reload
+   sudo tljh-config add-item users.admin <username>
+   sudo tljh-config reload
 
 If the user is already using the JupyterHub, they might have to stop and
 start their server from the control panel to gain new powers.
@@ -92,8 +92,8 @@ an admin terminal:
 
 .. code-block:: bash
 
-   sudo -E tljh-config remove-item users.admin <username>
-   sudo -E tljh-config reload
+   sudo tljh-config remove-item users.admin <username>
+   sudo tljh-config reload
 
 If the user is already using the JupyterHub, they will continue to have
 some of their admin powers until their server is stopped. Another admin

--- a/docs/howto/admin/https.rst
+++ b/docs/howto/admin/https.rst
@@ -19,15 +19,15 @@ Automatic HTTPS with Let's Encrypt
 
 To enable HTTPS via letsencrypt::
 
-    sudo -E tljh-config set https.enabled true
-    sudo -E tljh-config set https.letsencrypt.email you@example.com
-    sudo -E tljh-config add-item https.letsencrypt.domains yourhub.yourdomain.edu
+    sudo tljh-config set https.enabled true
+    sudo tljh-config set https.letsencrypt.email you@example.com
+    sudo tljh-config add-item https.letsencrypt.domains yourhub.yourdomain.edu
 
 where ``you@example.com`` is your email address and ``yourhub.yourdomain.edu`` is the domain where your hub will be running.
 
 Once you have loaded this, your config should look like::
 
-    sudo -E tljh-config show
+    sudo tljh-config show
 
 
 .. sourcecode:: yaml
@@ -41,7 +41,7 @@ Once you have loaded this, your config should look like::
 
 Finally, you can reload the proxy to load the new configuration::
 
-    sudo -E tljh-config reload proxy
+    sudo tljh-config reload proxy
 
 At this point, the proxy should negotiate with Let's Encrypt to set up a trusted HTTPS certificate for you.
 It may take a moment for the proxy to negotiate with Let's Encrypt to get your certificates, after which you can access your Hub securely at https://yourhub.yourdomain.edu.
@@ -54,14 +54,14 @@ Manual HTTPS with existing key and certificate
 You may already have an SSL key and certificate.
 If so, you can tell your deployment to use these files::
 
-    sudo -E tljh-config set https.enabled true
-    sudo -E tljh-config set https.tls.key /etc/mycerts/mydomain.key
-    sudo -E tljh-config set https.tls.cert /etc/mycerts/mydomain.cert
+    sudo tljh-config set https.enabled true
+    sudo tljh-config set https.tls.key /etc/mycerts/mydomain.key
+    sudo tljh-config set https.tls.cert /etc/mycerts/mydomain.cert
 
 
 Once you have loaded this, your config should look like::
 
-    sudo -E tljh-config show
+    sudo tljh-config show
 
 
 .. sourcecode:: yaml
@@ -74,6 +74,6 @@ Once you have loaded this, your config should look like::
 
 Finally, you can reload the proxy to load the new configuration::
 
-    sudo -E tljh-config reload proxy
+    sudo tljh-config reload proxy
 
 and now access your Hub securely at https://yourhub.yourdomain.edu.

--- a/docs/howto/auth/dummy.rst
+++ b/docs/howto/auth/dummy.rst
@@ -18,14 +18,14 @@ Enabling the authenticator
 
 .. code-block:: bash
    
-   sudo -E tljh-config set auth.DummyAuthenticator.password <password>
+   sudo tljh-config set auth.DummyAuthenticator.password <password>
 
    Remember to replace ``<password>`` with the password you choose.
 
 2. Enable the authenticator and reload config to apply configuration:
 
-   sudo -E tljh-config set auth.type dummyauthenticator.DummyAuthenticator
-   sudo -E tljh-config reload
+   sudo tljh-config set auth.type dummyauthenticator.DummyAuthenticator
+   sudo tljh-config reload
 
 Users who are currently logged in will continue to be logged in. When they 
 log out and try to log back in, they will be asked to provide a username and

--- a/docs/howto/auth/firstuse.rst
+++ b/docs/howto/auth/firstuse.rst
@@ -16,8 +16,8 @@ Enabling the authenticator
 
 #. Enable the authenticator and reload config to apply the configuration:
 
-   sudo -E tljh-config set auth.type firstuseauthenticator.FirstUseAuthenticator
-   sudo -E tljh-config reload
+   sudo tljh-config set auth.type firstuseauthenticator.FirstUseAuthenticator
+   sudo tljh-config reload
 
 Users who are currently logged in will continue to be logged in. When they
 log out and try to log back in, they will be asked to provide a username and

--- a/docs/howto/auth/github.rst
+++ b/docs/howto/auth/github.rst
@@ -57,19 +57,19 @@ For more information on ``tljh-config``, see :ref:`topic/tljh-config`.
 
 #. Configure the GitHub OAuthenticator to use your client ID and secret with the following commands::
 
-     sudo -E tljh-config set auth.GitHubOAuthenticator.client_id '<my-tljh-client-id>'
+     sudo tljh-config set auth.GitHubOAuthenticator.client_id '<my-tljh-client-id>'
 
    ::
 
-     sudo -E tljh-config set auth.GitHubOAuthenticator.client_secret '<my-tljh-client-secret>'
+     sudo tljh-config set auth.GitHubOAuthenticator.client_secret '<my-tljh-client-secret>'
 
 #. Tell your JupyterHub to *use* the GitHub OAuthenticator for authentication::
 
-     sudo -E tljh-config set auth.type oauthenticator.github.GitHubOAuthenticator
+     sudo tljh-config set auth.type oauthenticator.github.GitHubOAuthenticator
 
 #. Restart your JupyterHub so that new users see these changes::
 
-     sudo -E tljh-config reload
+     sudo tljh-config reload
 
 Confirm that the new authentactor works
 =======================================

--- a/docs/howto/content/add-data.rst
+++ b/docs/howto/content/add-data.rst
@@ -81,7 +81,7 @@ time. You can download it from your browser `at this link <https://swcarpentry.g
 
    .. code-block:: bash
 
-      sudo -E apt-get install unzip
+      sudo apt install unzip
 
 #. Finally, unzip the the file:
 

--- a/docs/howto/content/share-data.rst
+++ b/docs/howto/content/share-data.rst
@@ -37,7 +37,7 @@ steps:
 
    .. code-block:: bash
 
-      sudo -E mkdir -p /srv/data/my_shared_data_folder
+      sudo mkdir -p /srv/data/my_shared_data_folder
 
 #. **Download the data** into this folder. See :ref:`howto/content/add-data` for
    details on how to do this.

--- a/docs/howto/env/notebook-interfaces.rst
+++ b/docs/howto/env/notebook-interfaces.rst
@@ -36,19 +36,19 @@ You can change the default interface users get when they log in by modifying
 
    .. code-block:: yaml
 
-      sudo -E tljh-config set user_environment.default_app jupyterlab
+      sudo tljh-config set user_environment.default_app jupyterlab
 
 #. Alternatively, to launch **nteract** when users log in, run the following in the admin console:
 
    .. code-block:: yaml
 
-      sudo -E tljh-config set user_environment.default_app nteract
+      sudo tljh-config set user_environment.default_app nteract
 
 #. Apply the changes by restarting JupyterHub. This should not disrupt current users.
 
    .. code-block:: yaml
 
-      sudo -E tljh-config reload
+      sudo tljh-config reload
 
    If this causes problems, check the :ref:`troubleshoot_logs_jupyterhub` for clues
    on what went wrong.

--- a/docs/topic/authenticator-configuration.rst
+++ b/docs/topic/authenticator-configuration.rst
@@ -35,7 +35,7 @@ You can set these with ``tljh-config`` with:
 
 .. code-block:: bash
 
-   sudo -E tljh-config set auth.<AuthenticatorName>.<property-name> <some-value>
+   sudo tljh-config set auth.<AuthenticatorName>.<property-name> <some-value>
 
 Example
 -------
@@ -47,7 +47,7 @@ to some value, you can do that with the following command:
 
 .. code-block:: bash
 
-   sudo -E tljh-config set auth.LDAPAuthenticator.server_address = 'my-ldap-server'
+   sudo tljh-config set auth.LDAPAuthenticator.server_address = 'my-ldap-server'
 
 Most authenticators require you set multiple configuration options before you can
 enable them. Read the authenticator's documentation carefully for more information.
@@ -67,13 +67,13 @@ You can accomplish the same with ``tljh-config``:
 
 .. code-block:: bash
 
-   sudo -E tljh-config set auth.type <fully-qualified-authenticator-name>
+   sudo tljh-config set auth.type <fully-qualified-authenticator-name>
 
 Once enabled, you need to reload JupyterHub for the config to take effect.
 
 .. code-block:: bash
 
-   sudo -E tljh-config reload
+   sudo tljh-config reload
 
 Try logging in a separate incognito window to check if your configuration works. This
 lets you preserve your terminal in case there were errors. If there are
@@ -88,5 +88,5 @@ Assuming you have already configured it, the following commands enable LDAPAuthe
 
 .. code-block:: bash
 
-   sudo -E tljh-config set auth.type ldapauthenticator.LDAPAuthenticator
-   sudo -E tljh-config reload
+   sudo tljh-config set auth.type ldapauthenticator.LDAPAuthenticator
+   sudo tljh-config reload

--- a/docs/topic/installer-actions.rst
+++ b/docs/topic/installer-actions.rst
@@ -51,11 +51,11 @@ By default, ``sudo`` does not respect any custom environments you have activated
 ``tljh-config`` symlink
 ========================
 
-We create a symlink from ``/usr/local/bin/tljh-config`` to ``/opt/tljh/hub/bin/tljh-cohnfig``, so users
-can run ``sudo -E tljh-config <somethihng>`` from their terminal. While the user environment is added
+We create a symlink from ``/usr/bin/tljh-config`` to ``/opt/tljh/hub/bin/tljh-cohnfig``, so users
+can run ``sudo tljh-config <somethihng>`` from their terminal. While the user environment is added
 to users' ``$PATH`` when they launch through JupyterHub, the hub environment is not. This makes it
 hard to access the ``tljh-config`` command used to change most config parameters. Hence we symlink the
-``tljh-config`` command to ``/usr/local/bin``, so it is directly accessible with ``sudo -E tljh-config <command>``.
+``tljh-config`` command to ``/usr/local/bin``, so it is directly accessible with ``sudo tljh-config <command>``.
 
 Systemd Units
 =============

--- a/docs/topic/tljh-config.rst
+++ b/docs/topic/tljh-config.rst
@@ -27,7 +27,7 @@ set a particular property with the following command:
 
 .. code-block:: bash
 
-   sudo -E tljh-config set <property-path> <value>
+   sudo tljh-config set <property-path> <value>
 
 
 where:
@@ -42,7 +42,7 @@ do so with the following:
 
 .. code-block:: bash
 
-   sudo -E tljh-config set auth.DummyAuthenticator.password mypassword
+   sudo tljh-config set auth.DummyAuthenticator.password mypassword
 
 
 This can only set string and numerical properties, not lists.
@@ -54,7 +54,7 @@ To see the current configuration, you can run the following command:
 
 .. code-block:: bash
 
-   sudo -E tljh-config show
+   sudo tljh-config show
 
 This will print the current configuration of your TLJH. This is very
 useful when asking for support!
@@ -67,7 +67,7 @@ it to take effect. You can do so with:
 
 .. code-block:: bash
 
-   sudo -E tljh-config reload
+   sudo tljh-config reload
 
 This should not affect any running users. The JupyterHub will be
 restarted and loaded with the new configuration.

--- a/integration-tests/test_hub.py
+++ b/integration-tests/test_hub.py
@@ -12,7 +12,7 @@ import sys
 
 # Use sudo to invoke it, since this is how users invoke it.
 # This catches issues with PATH
-TLJH_CONFIG_PATH = ['sudo', '-E', 'tljh-config']
+TLJH_CONFIG_PATH = ['sudo', 'tljh-config']
 
 def test_hub_up():
     r = requests.get('http://127.0.0.1')

--- a/integration-tests/test_install.py
+++ b/integration-tests/test_install.py
@@ -209,4 +209,4 @@ def test_symlinks():
     """
     Test we symlink tljh-config to /usr/local/bin
     """
-    assert os.path.exists('/usr/local/bin/tljh-config')
+    assert os.path.exists('/usr/bin/tljh-config')

--- a/tljh/installer.py
+++ b/tljh/installer.py
@@ -286,22 +286,24 @@ def ensure_jupyterhub_running(times=4):
 
 def ensure_symlinks(prefix):
     """
-    Ensure we symlink appropriate things into /usr/local/bin
+    Ensure we symlink appropriate things into /usr/bin
 
     We add the user conda environment to PATH for notebook terminals,
     but not the hub venv. This means tljh-config is not actually accessible.
 
-    We symlink to /usr/local/bin to 'fix' this. /usr/local/bin is the appropriate
-    place, and works with sudo -E
+    We symlink to /usr/bin and not /usr/local/bin, since /usr/local/bin is
+    not place, and works with sudo -E in sudo's search $PATH. We can work
+    around this with sudo -E and extra entries in the sudoers file, but this
+    is far more secure at the cost of upsetting some FHS purists.
     """
     tljh_config_src = os.path.join(prefix, 'bin', 'tljh-config')
-    tljh_config_dest = '/usr/local/bin/tljh-config'
+    tljh_config_dest = '/usr/bin/tljh-config'
     if os.path.exists(tljh_config_dest):
         if os.path.realpath(tljh_config_dest) != tljh_config_src:
             #  tljh-config exists that isn't ours. We should *not* delete this file,
             # instead we throw an error and abort. Deleting files owned by other people
             # while running as root is dangerous, especially with symlinks involved.
-            raise FileExistsError(f'/usr/local/bin/tljh-config exists but is not a symlink to {tljh_config_src}')
+            raise FileExistsError(f'/usr/bin/tljh-config exists but is not a symlink to {tljh_config_src}')
         else:
             # We have a working symlink, so do nothing
             return


### PR DESCRIPTION
Removes a lot of 'sudo -E' usage, and eventually should
let us get rid of the $PATH override for jupyterhub-admins,
which arguably is less secure than just dropping stuff into
/usr/bin