### PR TITLE
Use node 8, not 10

### DIFF
--- a/tljh/installer.py
+++ b/tljh/installer.py
@@ -92,7 +92,7 @@ sckuXINIU3DFWzZGr0QrqkuE/jyr7FXeUJj9B7cLo+s/TXo+RaVfi3kOc9BoxIvy
 -----END PGP PUBLIC KEY BLOCK-----
     """.strip()
     apt.trust_gpg_key(key)
-    apt.add_source('nodesource', f'https://deb.nodesource.com/node_10.x', 'main')
+    apt.add_source('nodesource', f'https://deb.nodesource.com/node_8.x', 'main')
     apt.install_packages(['nodejs'])
 
 


### PR DESCRIPTION
JupyterLab currently doesn't let you install extensions
with node 10, so move back to 8

 <!-- Read more about our code-review guidelines at https://the-littlest-jupyterhub.readthedocs.io/en/latest/contributing/code-review.html -->