### PR TITLE
Fix link to custom server install

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,7 +48,7 @@ Ubuntu 18.04. We have a bunch of tutorials to get you started!
   - ... your favorite provider here, if you can contribute!
 
 - `Tutorial to install TLJH on an already running server you have root access to
-  <https://the-littlest-jupyterhub.readthedocs.io/en/latest/install/custom.html>`_.
+  <https://the-littlest-jupyterhub.readthedocs.io/en/latest/install/custom-server.html>`_.
   You should use this if your cloud provider does not already have a direct tutorial,
   or if you have experience setting up servers.
 


### PR DESCRIPTION
The URL for the custom server install page on readthedocs was pointing to a non-existing page.  Added the "-server" suffix to the page name.

 - [ ] Add / update documentation
 - [ ] Add tests

 <!-- Read more about our code-review guidelines at https://the-littlest-jupyterhub.readthedocs.io/en/latest/contributing/code-review.html -->