### PR TITLE
Don't capture stderr when calling conda

### DIFF
--- a/tljh/conda.py
+++ b/tljh/conda.py
@@ -84,13 +84,15 @@ def ensure_conda_packages(prefix, packages):
     conda_executable = [os.path.join(prefix, 'bin', 'python'), '-m', 'conda']
     abspath = os.path.abspath(prefix)
     # Let subprocess errors propagate
+    # Explicitly do *not* capture stderr, since that's not always JSON!
+    # Scripting conda is a PITA!
     # FIXME: raise different exception when using
     raw_output = subprocess.check_output(conda_executable + [
         'install',
         '-c', 'conda-forge',  # Make customizable if we ever need to
         '--json',
         '--prefix', abspath
-    ] + packages, stderr=subprocess.STDOUT).decode()
+    ] + packages).decode()
     # `conda install` outputs JSON lines for fetch updates,
     # and a undelimited output at the end. There is no reasonable way to
     # parse this outside of this kludge.


### PR DESCRIPTION
conda's stderr is *not* guaranteed to be JSON when you are
passing --json. We let it bleed through for now. In the
longer term, we should capture this separately.

Ref #148, which I think is caused by this (along with conda
releasing a newer version than what we have