### PR TITLE
Don't set a memory limit by default

### DIFF
--- a/tljh/configurer.py
+++ b/tljh/configurer.py
@@ -28,7 +28,7 @@ default = {
         'admin': [],
     },
     'limits': {
-        'memory': '1G',
+        'memory': None,
         'cpu': None,
     },
     'http': {


### PR DESCRIPTION
Users should set up their own memory limits after install.
Better than a surprise when they try using more than 1G.

 - [ ] Add / update documentation
 - [ ] Add tests

 <!-- Read more about our code-review guidelines at https://the-littlest-jupyterhub.readthedocs.io/en/latest/contributing/code-review.html -->