### PR TITLE
Draft tool to change password when using Firsttimeauthrenticator

### DIFF
--- a/tools/passwd.py
+++ b/tools/passwd.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+# hub bin python3
+import dbm
+from getpass import getpass
+
+import bcrypt
+
+install_prefix = os.environ.get('TLJH_INSTALL_PREFIX', '/opt/tljh')
+
+if __name__ == '__main__':
+    print('create user or update password:')
+    username = input('Username: ').encode()
+    password = getpass()
+    with dbm.open(install_prefix+'/state/passwords.dbm', 'c', 0o600) as db:
+        db[username] = bcrypt.hashpw(password.encode(), bcrypt.gensalt())
+    print('password for user `{username}` created or updated'.format(username=username))
+


### PR DESCRIPTION
By default TLJH uses first time authenticator, and obviously users may
forget their passwords. This provide a base as to how a CLI tools may be
provided to allow a root user to update a password for a given user

 - [ ] Add / update documentation
 - [ ] Add tests


Things to add on top of this:
 - Documentation
 - Run it with the right python. 

Is there any thoughts of providing a small `tljh` command that can be use to do basic adminitration of `tljh` ? 