### PR TITLE
Fix some typos

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ Development Status
 ==================
 
 This project is currently in **alpha** state. Most things work, but we might
-still make breaking changes that have no clear upgrade pathway. We are targetting
+still make breaking changes that have no clear upgrade pathway. We are targeting
 a v0.1 release sometime in mid-August 2018. Follow `this milestone <https://github.com/jupyterhub/the-littlest-jupyterhub/milestone/1>`_
 to see progress towards the release!
 

--- a/docs/howto/admin/resource-estimation.rst
+++ b/docs/howto/admin/resource-estimation.rst
@@ -20,7 +20,7 @@ installations.
 
 
 The ``128MB`` is overhead for TLJH and related services. **Server Memory Recommended**
-is the amount of Memory (RAM) the server you aquire should have - we recommend
+is the amount of Memory (RAM) the server you acquire should have - we recommend
 erring on the side of 'more Memory'. The other terms are explained below.
 
 Maximum concurrent users

--- a/docs/howto/env/user-environment.rst
+++ b/docs/howto/env/user-environment.rst
@@ -14,7 +14,7 @@ easily.
 Installing pip packages
 =======================
 
-`pip <https://pypi.org/project/pip/>`_ is the recomended tool for installing packages
+`pip <https://pypi.org/project/pip/>`_ is the recommended tool for installing packages
 in Python from the `Python Packaging Index (PyPI) <https://pypi.org/>`_. PyPI has
 almost 145,000 packages in it right now, so a lot of what you need is going to be there!
 
@@ -115,7 +115,7 @@ make sure to look in the version of Ubuntu you are using!
 User environment location
 =========================
 
-The user environment is a conda enviornment set up in ``/opt/tljh/user``, with
+The user environment is a conda environment set up in ``/opt/tljh/user``, with
 a Python3 kernel as the default. It is readable by all users, but writeable only
 by users who have root access. This makes it possible for JupyterHub admins (who have
 root access with ``sudo``) to install software in the user environment easily.

--- a/integration-tests/plugins/simplest/tljh_simplest.py
+++ b/integration-tests/plugins/simplest/tljh_simplest.py
@@ -1,5 +1,5 @@
 """
-Simplest plugin that excercises all the hooks
+Simplest plugin that exercises all the hooks
 """
 from tljh.hooks import hookimpl
 

--- a/tljh/config.py
+++ b/tljh/config.py
@@ -244,7 +244,7 @@ def main(argv=None):
     )
     set_parser.add_argument(
         'value',
-        help='Value ot set the configuration key to'
+        help='Value to set the configuration key to'
     )
 
     add_item_parser = subparsers.add_parser(

--- a/tljh/systemd.py
+++ b/tljh/systemd.py
@@ -21,7 +21,7 @@ def reload_daemon():
 
 def install_unit(name, unit, path='/etc/systemd/system'):
     """
-    Install unit wih given name
+    Install unit with given name
     """
     with open(os.path.join(path, name), 'w') as f:
         f.write(unit)


### PR DESCRIPTION
Using `codespell -q3 -w` that I just discovered.

(https://github.com/codespell-project/codespell, pip install codespell)

And fixing one manually.
