### PR TITLE
put config in `$tljh/config` directory

### DIFF
--- a/docs/contributing/dev-setup.rst
+++ b/docs/contributing/dev-setup.rst
@@ -59,8 +59,8 @@ The easiest & safest way to develop & test TLJH is with `Docker <https://www.doc
      you can test it by running ``python3 -m tljh.installer``.
 
    * If you changed ``tljh/jupyterhub_config.py``, ``tljh/configurer.py``,
-     ``/opt/tljh/config.yaml`` or any of their dependencies, you only need to
-     restart jupyterhub for them to take effect. ``systemctl restart jupyterhub``
+     ``/opt/tljh/config/`` or any of their dependencies, you only need to
+     restart jupyterhub for them to take effect. ``tljh-config reload hub``
      should do that.
 
 :ref:`troubleshooting/logs` has information on looking at various logs in the container

--- a/docs/howto/env/notebook-interfaces.rst
+++ b/docs/howto/env/notebook-interfaces.rst
@@ -48,7 +48,7 @@ You can change the default interface users get when they log in by modifying
 
    .. code-block:: yaml
 
-      sudo tljh-config reload
+      sudo tljh-config reload hub
 
    If this causes problems, check the :ref:`troubleshoot_logs_jupyterhub` for clues
    on what went wrong.

--- a/docs/topic/escape-hatch.rst
+++ b/docs/topic/escape-hatch.rst
@@ -10,7 +10,7 @@ directory that lets you load multiple ``jupyterhub_config.py`` snippets for
 your configuration. You need to create the directory when you use it for
 the first time.
 
-Any files in ``/opt/tljh/jupyterhub_config.d`` that end in ``.py`` will be
+Any files in ``/opt/tljh/config/jupyterhub_config.d`` that end in ``.py`` will be
 loaded in alphabetical order as python files to provide configuration for
 JupyterHub. Any config that can go in a regular ``jupyterhub_config.py``
 file is valid in these files. They will be loaded *after* any of the config

--- a/integration-tests/test_simplest_plugin.py
+++ b/integration-tests/test_simplest_plugin.py
@@ -4,6 +4,7 @@ Test simplest plugin
 from ruamel.yaml import YAML
 import os
 import subprocess
+from tljh.config import CONFIG_FILE, USER_ENV_PREFIX
 
 yaml = YAML(typ='rt')
 
@@ -20,7 +21,7 @@ def test_pip_packages():
     Test extra user pip packages are installed
     """
     subprocess.check_call([
-        '/opt/tljh/user/bin/python3',
+        f'{USER_ENV_PREFIX}/bin/python3',
         '-c',
         'import django'
     ])
@@ -31,7 +32,7 @@ def test_conda_packages():
     Test extra user conda packages are installed
     """
     subprocess.check_call([
-        '/opt/tljh/user/bin/python3',
+        f'{USER_ENV_PREFIX}/bin/python3',
         '-c',
         'import hypothesis'
     ])
@@ -41,7 +42,7 @@ def test_config_hook():
     """
     Check config changes are present
     """
-    with open('/opt/tljh/config.yaml') as f:
+    with open(CONFIG_FILE) as f:
         data = yaml.load(f)
 
     assert data['simplest_plugin']['present']

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,4 +21,5 @@ def tljh_dir(tmpdir):
                 reload(mod)
         assert tljh.config.INSTALL_PREFIX == tljh_dir
         os.makedirs(tljh.config.STATE_DIR)
+        os.makedirs(tljh.config.CONFIG_DIR)
         yield tljh_dir

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -1,10 +1,57 @@
 """
 Unit test  functions in installer.py
 """
-from tljh import installer
 import os
+from datetime import date
+
+from tljh import installer
+
 
 
 def test_ensure_node():
     installer.ensure_node()
     assert os.path.exists('/usr/bin/node')
+
+
+def test_ensure_config_yaml(tljh_dir):
+    pm = installer.setup_plugins()
+    installer.ensure_config_yaml(pm)
+    assert os.path.exists(installer.CONFIG_FILE)
+    assert os.path.isdir(installer.CONFIG_DIR)
+    assert os.path.isdir(os.path.join(installer.CONFIG_DIR, 'jupyterhub_config.d'))
+    assert not os.path.exists(installer.OLD_CONFIG_FILE)
+
+    # run again, with old config in the way and no new config
+    upgraded_config = 'old: config\n'
+    with open(installer.OLD_CONFIG_FILE, 'w') as f:
+        f.write(upgraded_config)
+    os.remove(installer.CONFIG_FILE)
+    installer.ensure_config_yaml(pm)
+    assert os.path.exists(installer.CONFIG_FILE)
+    assert not os.path.exists(installer.OLD_CONFIG_FILE)
+    with open(installer.CONFIG_FILE) as f:
+        assert f.read() == upgraded_config
+
+    # run again, this time with both old and new config
+    duplicate_config = 'dupe: config\n'
+    with open(installer.OLD_CONFIG_FILE, 'w') as f:
+        f.write(duplicate_config)
+    installer.ensure_config_yaml(pm)
+    assert os.path.exists(installer.CONFIG_FILE)
+    assert not os.path.exists(installer.OLD_CONFIG_FILE)
+    # didn't clobber config:
+    with open(installer.CONFIG_FILE) as f:
+        assert f.read() == upgraded_config
+
+    # preserved old config
+    backup_config = installer.CONFIG_FILE + f".old.{date.today().isoformat()}"
+    assert os.path.exists(backup_config)
+    with open(backup_config) as f:
+        assert f.read() == duplicate_config
+
+
+
+
+
+
+

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -2,10 +2,8 @@
 Unit test  functions in installer.py
 """
 import os
-from datetime import date
 
 from tljh import installer
-
 
 
 def test_ensure_node():
@@ -19,39 +17,5 @@ def test_ensure_config_yaml(tljh_dir):
     assert os.path.exists(installer.CONFIG_FILE)
     assert os.path.isdir(installer.CONFIG_DIR)
     assert os.path.isdir(os.path.join(installer.CONFIG_DIR, 'jupyterhub_config.d'))
-    assert not os.path.exists(installer.OLD_CONFIG_FILE)
-
-    # run again, with old config in the way and no new config
-    upgraded_config = 'old: config\n'
-    with open(installer.OLD_CONFIG_FILE, 'w') as f:
-        f.write(upgraded_config)
-    os.remove(installer.CONFIG_FILE)
-    installer.ensure_config_yaml(pm)
-    assert os.path.exists(installer.CONFIG_FILE)
-    assert not os.path.exists(installer.OLD_CONFIG_FILE)
-    with open(installer.CONFIG_FILE) as f:
-        assert f.read() == upgraded_config
-
-    # run again, this time with both old and new config
-    duplicate_config = 'dupe: config\n'
-    with open(installer.OLD_CONFIG_FILE, 'w') as f:
-        f.write(duplicate_config)
-    installer.ensure_config_yaml(pm)
-    assert os.path.exists(installer.CONFIG_FILE)
-    assert not os.path.exists(installer.OLD_CONFIG_FILE)
-    # didn't clobber config:
-    with open(installer.CONFIG_FILE) as f:
-        assert f.read() == upgraded_config
-
-    # preserved old config
-    backup_config = installer.CONFIG_FILE + f".old.{date.today().isoformat()}"
-    assert os.path.exists(backup_config)
-    with open(backup_config) as f:
-        assert f.read() == duplicate_config
-
-
-
-
-
-
-
+    # verify that old config doesn't exist
+    assert not os.path.exists(os.path.join(tljh_dir, 'config.yaml'))

--- a/tests/test_migrator.py
+++ b/tests/test_migrator.py
@@ -1,0 +1,57 @@
+"""
+Unit test  functions in installer.py
+"""
+import os
+from datetime import date
+
+from tljh import migrator, config
+
+
+def test_migrate_config(tljh_dir):
+    CONFIG_FILE = config.CONFIG_FILE
+    CONFIG_DIR = config.CONFIG_DIR
+    OLD_CONFIG_FILE = os.path.join(tljh_dir, "config.yaml")
+    OLD_CONFIG_D = os.path.join(tljh_dir, "jupyterhub_config.d")
+    CONFIG_D = os.path.join(config.CONFIG_DIR, "jupyterhub_config.d")
+    old_config_py = os.path.join(OLD_CONFIG_D, "upgrade.py")
+    new_config_py = os.path.join(CONFIG_D, "upgrade.py")
+
+    # initial condition: nothing exists
+    assert not os.path.exists(CONFIG_FILE)
+    assert not os.path.exists(OLD_CONFIG_FILE)
+    assert os.path.isdir(CONFIG_DIR)
+
+    # run migration with old config and no new config
+    upgraded_config = "old: config\n"
+    with open(OLD_CONFIG_FILE, "w") as f:
+        f.write(upgraded_config)
+    os.makedirs(OLD_CONFIG_D, exist_ok=True)
+    with open(old_config_py, "w") as f:
+        f.write("c.JupyterHub.log_level = 10")
+
+    migrator.migrate_config_files()
+    assert os.path.exists(CONFIG_FILE)
+    assert not os.path.exists(OLD_CONFIG_FILE)
+    with open(CONFIG_FILE) as f:
+        assert f.read() == upgraded_config
+    assert os.path.exists(new_config_py)
+    assert not os.path.exists(OLD_CONFIG_D)
+
+    # run again, this time with both old and new config
+    duplicate_config = "dupe: config\n"
+    with open(OLD_CONFIG_FILE, "w") as f:
+        f.write(duplicate_config)
+    migrator.migrate_config_files()
+    assert os.path.exists(CONFIG_FILE)
+    assert not os.path.exists(OLD_CONFIG_FILE)
+    # didn't clobber config:
+    with open(CONFIG_FILE) as f:
+        assert f.read() == upgraded_config
+
+    # preserved old config
+    backup_config = CONFIG_FILE + f".old.{date.today().isoformat()}"
+    assert os.path.exists(backup_config)
+    with open(backup_config) as f:
+        assert f.read() == duplicate_config
+
+    # migrate jupyterhub_con

--- a/tljh/config.py
+++ b/tljh/config.py
@@ -30,9 +30,6 @@ STATE_DIR = os.path.join(INSTALL_PREFIX, 'state')
 CONFIG_DIR = os.path.join(INSTALL_PREFIX, 'config')
 CONFIG_FILE = os.path.join(CONFIG_DIR, 'config.yaml')
 
-# deprecated config file location
-OLD_CONFIG_FILE = os.path.join(INSTALL_PREFIX, 'config.yaml')
-
 
 def set_item_in_config(config, property_path, value):
     """

--- a/tljh/config.py
+++ b/tljh/config.py
@@ -27,7 +27,11 @@ INSTALL_PREFIX = os.environ.get('TLJH_INSTALL_PREFIX', '/opt/tljh')
 HUB_ENV_PREFIX = os.path.join(INSTALL_PREFIX, 'hub')
 USER_ENV_PREFIX = os.path.join(INSTALL_PREFIX, 'user')
 STATE_DIR = os.path.join(INSTALL_PREFIX, 'state')
-CONFIG_FILE = os.path.join(INSTALL_PREFIX, 'config.yaml')
+CONFIG_DIR = os.path.join(INSTALL_PREFIX, 'config')
+CONFIG_FILE = os.path.join(CONFIG_DIR, 'config.yaml')
+
+# deprecated config file location
+OLD_CONFIG_FILE = os.path.join(INSTALL_PREFIX, 'config.yaml')
 
 
 def set_item_in_config(config, property_path, value):

--- a/tljh/config.py
+++ b/tljh/config.py
@@ -225,6 +225,9 @@ def main(argv=None):
     if argv is None:
         argv = sys.argv[1:]
 
+    from .log import init_logging
+    init_logging()
+
     argparser = argparse.ArgumentParser()
     argparser.add_argument(
         '--config-path',

--- a/tljh/installer.py
+++ b/tljh/installer.py
@@ -31,19 +31,7 @@ HERE = os.path.abspath(os.path.dirname(__file__))
 
 rt_yaml = YAML()
 
-# Set up logging to print to a file and to stderr
 logger = logging.getLogger(__name__)
-
-os.makedirs(INSTALL_PREFIX, exist_ok=True)
-file_logger = logging.FileHandler(os.path.join(INSTALL_PREFIX, 'installer.log'))
-file_logger.setFormatter(logging.Formatter('%(asctime)s %(message)s'))
-logger.addHandler(file_logger)
-
-stderr_logger = logging.StreamHandler()
-stderr_logger.setFormatter(logging.Formatter('%(message)s'))
-logger.addHandler(stderr_logger)
-logger.setLevel(logging.INFO)
-
 
 def ensure_node():
     """
@@ -423,6 +411,9 @@ def ensure_config_yaml(plugin_manager):
 
 
 def main():
+    from .log import init_logging
+    init_logging()
+
     argparser = argparse.ArgumentParser()
     argparser.add_argument(
         '--admin',

--- a/tljh/installer.py
+++ b/tljh/installer.py
@@ -336,7 +336,7 @@ def ensure_symlinks(prefix):
     os.symlink(tljh_config_src, tljh_config_dest)
 
 
-def setup_plugins(plugins):
+def setup_plugins(plugins=None):
     """
     Install plugins & setup a pluginmanager
     """

--- a/tljh/jupyterhub_config.py
+++ b/tljh/jupyterhub_config.py
@@ -40,7 +40,7 @@ c.SystemdSpawner.default_shell = '/bin/bash'
 # Drop the '-singleuser' suffix present in the default template
 c.SystemdSpawner.unit_name_template = 'jupyter-{USERNAME}'
 
-config_overrides_path = os.path.join(INSTALL_PREFIX, 'config.yaml')
+config_overrides_path = os.path.join(CONFIG_DIR, 'config.yaml')
 if os.path.exists(config_overrides_path):
     with open(config_overrides_path) as f:
         config_overrides = yaml.safe_load(f)

--- a/tljh/jupyterhub_config.py
+++ b/tljh/jupyterhub_config.py
@@ -8,7 +8,7 @@ from glob import glob
 
 from systemdspawner import SystemdSpawner
 from tljh import user, configurer
-from tljh.config import INSTALL_PREFIX, USER_ENV_PREFIX
+from tljh.config import INSTALL_PREFIX, USER_ENV_PREFIX, CONFIG_DIR
 
 
 class CustomSpawner(SystemdSpawner):
@@ -50,6 +50,6 @@ configurer.apply_config(config_overrides, c)
 
 # Load arbitrary .py config files if they exist.
 # This is our escape hatch
-extra_configs = sorted(glob(os.path.join(INSTALL_PREFIX, 'jupyterhub_config.d', '*.py')))
+extra_configs = sorted(glob(os.path.join(CONFIG_DIR, 'jupyterhub_config.d', '*.py')))
 for ec in extra_configs:
     load_subconfig(ec)

--- a/tljh/log.py
+++ b/tljh/log.py
@@ -1,0 +1,19 @@
+"""Setup tljh logging"""
+import os
+import logging
+
+from .config import INSTALL_PREFIX
+
+
+def init_logging():
+    """Setup default tljh logger"""
+    logger = logging.getLogger("tljh")
+    os.makedirs(INSTALL_PREFIX, exist_ok=True)
+    file_logger = logging.FileHandler(os.path.join(INSTALL_PREFIX, "installer.log"))
+    file_logger.setFormatter(logging.Formatter("%(asctime)s %(message)s"))
+    logger.addHandler(file_logger)
+
+    stderr_logger = logging.StreamHandler()
+    stderr_logger.setFormatter(logging.Formatter("%(message)s"))
+    logger.addHandler(stderr_logger)
+    logger.setLevel(logging.INFO)

--- a/tljh/migrator.py
+++ b/tljh/migrator.py
@@ -1,0 +1,69 @@
+"""Migration utilities for upgrading tljh"""
+
+import os
+from datetime import date
+import logging
+import shutil
+
+from tljh.config import (
+    CONFIG_DIR,
+    CONFIG_FILE,
+    INSTALL_PREFIX,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+def migrate_file(old_path, new_path):
+    """Migrate one file from an old location to a new one
+
+    avoids collisions if the new file exists
+    """
+    if not os.path.exists(old_path):
+        return
+    if os.path.exists(new_path):
+        # new config file already created! still move the config,
+        # but avoid collision
+        timestamp = date.today().isoformat()
+        dest = dest_base = f"{new_path}.old.{timestamp}"
+        i = 0
+        while os.path.exists(dest):
+            # avoid collisions
+            dest = dest_base + f".{i}"
+            i += 1
+        logger.warning(f"Found file in both old ({old_path}) and new ({new_path}).")
+        logger.warning(
+            f"Moving {old_path} to {dest} to avoid clobbering.  Its contents will be ignored."
+        )
+    else:
+        dest = new_path
+    shutil.move(old_path, dest)
+
+
+def migrate_directory(old_dir, new_dir):
+    """Migrate a directory to a new location"""
+    if not os.path.exists(old_dir):
+        return
+    if os.path.exists(new_dir):
+        # both dirs exist
+        for f in os.listdir(old_dir):
+            src = os.path.join(old_dir, f)
+            dest = os.path.join(new_dir, f)
+            if os.path.isdir(src):
+                migrate_directory(src, dest)
+            else:
+                migrate_file(src, dest)
+    else:
+        logger.warning(f"Moving directory to new location {old_dir} -> {new_dir}")
+        shutil.move(old_dir, new_dir)
+
+
+def migrate_config_files():
+    """Migrate config files to their new locations"""
+    # handle old TLJH_DIR/config.yaml location
+    migrate_file(os.path.join(INSTALL_PREFIX, "config.yaml"), CONFIG_FILE)
+    migrate_directory(
+        os.path.join(INSTALL_PREFIX, "jupyterhub_config.d"),
+        os.path.join(CONFIG_DIR, "jupyterhub_config.d"),
+    )


### PR DESCRIPTION
easier to maintain proper private permissions and consolidate, since we have multiple config files (config.yaml, jupyterhub_config.d)

I thought there was an issue about this, but I can't seem to find it right now.

- [x] Add / update documentation
- [x] Add tests