### PR TITLE
installer.py: remove unused f"..."

### DIFF
--- a/tljh/installer.py
+++ b/tljh/installer.py
@@ -92,7 +92,7 @@ sckuXINIU3DFWzZGr0QrqkuE/jyr7FXeUJj9B7cLo+s/TXo+RaVfi3kOc9BoxIvy
 -----END PGP PUBLIC KEY BLOCK-----
     """.strip()
     apt.trust_gpg_key(key)
-    apt.add_source('nodesource', f'https://deb.nodesource.com/node_8.x', 'main')
+    apt.add_source('nodesource', 'https://deb.nodesource.com/node_8.x', 'main')
     apt.install_packages(['nodejs'])
 
 


### PR DESCRIPTION
removed formatting  symbol f'', since "....x" is considered as a type in the formatting.
actual directory  is just "https://github.com/nodesource/distributions/blob/master/deb/setup_8.x"

 - [ ] Add / update documentation
 - [ ] Add tests

 <!-- Read more about our code-review guidelines at https://the-littlest-jupyterhub.readthedocs.io/en/latest/contributing/code-review.html -->