### PR TITLE
Don't create home publicly readable

### DIFF
--- a/docs/topic/security.rst
+++ b/docs/topic/security.rst
@@ -22,6 +22,10 @@ permissions.
 
 #. A home directory is created for the user under ``/home/jupyter-<username>``.
 
+#. The default permission of the home directory is change with ``o-rwx`` (remove
+   non-group members the ability to read, write or list files and folders in the
+   Home directory).
+
 #. No password is set for this unix system user by default. The password used
    to log in to JupyterHub (if using an authenticator that requires a password)
    is not related to the unix user's password in any form.

--- a/tljh/user.py
+++ b/tljh/user.py
@@ -6,6 +6,7 @@ Supports minimal user & group management
 import pwd
 import grp
 import subprocess
+from os.path import expanduser
 
 
 def ensure_user(username):
@@ -25,6 +26,12 @@ def ensure_user(username):
         'useradd',
         '--create-home',
         username
+    ])
+
+    subprocess.check_call([
+        'chmod',
+        'o-rwx', 
+        expanduser('~{username}'.format(username=username))
     ])
 
 


### PR DESCRIPTION
World-Readable seem to be a surprising default for many people,
especially in teaching context. Switch to a more reasonable `rwxr-x---`

We have to issue a chmod, as changing at creation time would require
changin /etc/adduser.conf DIR_MODE=0760 (or whatever), but that seem
unwise.

We do not set the exact permission in case the DIR_MODE is more
restrictive.

Closing #158

 - [x] Add / update documentation
 - [x] Add tests

(cc @mstobb)

One question is do we want that to be configurable ? I tend to think no.