### PR TITLE
Fix minor typo: pypy -> pypi

### DIFF
--- a/docs/topic/customizing-installer.rst
+++ b/docs/topic/customizing-installer.rst
@@ -68,7 +68,7 @@ research, a stack for a praticular class, etc.
 ``--plugin <plugin-to-install>`` installs and activates a plugin. You can pass it
 however many times you want. Since plugins are distributed as python packages,
 ``<plugin-to-install>`` can be anything that can be passed to ``pip install`` -
-``plugin-name-on-pypy==<version>`` and ``git+https://github.com/user/repo@tag``
+``plugin-name-on-pypi==<version>`` and ``git+https://github.com/user/repo@tag``
 are the most popular ones. Specifying a version or tag is highly recommended.
 
 For example, to install the PANGEO Plugin version 0.1 in your new TLJH install,


### PR DESCRIPTION
 - [x] Add / update documentation

Looks like [pypi.org](https://pypi.org) was intended :)