### PR TITLE
updating theme and storing docs artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,6 +123,10 @@ jobs:
                     cd docs
                     make html
 
+            - store_artifacts:
+                path: docs/_build/html/
+                destination: html
+
 workflows:
     version: 2
     all-tests:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,7 +34,10 @@ intersphinx_cache_limit = 90 # days
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'
 
-html_theme = 'alabaster'
+import alabaster_jupyterhub
+
+html_theme = 'alabaster_jupyterhub'
+html_theme_path = [alabaster_jupyterhub.get_html_theme_path()]
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/docs/doc-requirements.txt
+++ b/docs/doc-requirements.txt
@@ -1,1 +1,0 @@
-sphinx_copybutton

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,4 @@
 sphinx>=1.4, !=1.5.4
 sphinx_copybutton
+alabaster
+alabaster_jupyterhub


### PR DESCRIPTION
 - [X] Add / update documentation
 
This updates the documentation theme to the common jupyterhub one and stores artifacts as part of circle. It also deletes `doc-requirements.txt` because I think it wasn't being used at all