### PR TITLE
add warning if tljh-config is called as non-root user

### DIFF
--- a/tljh/config.py
+++ b/tljh/config.py
@@ -223,7 +223,11 @@ def main(argv=None):
         argv = sys.argv[1:]
 
     from .log import init_logging
-    init_logging()
+    try:
+        init_logging()
+    except Exception as e:
+        print(str(e))
+        print("Perhaps you didn't use `sudo -E`?")
 
     argparser = argparse.ArgumentParser()
     argparser.add_argument(
@@ -291,18 +295,22 @@ def main(argv=None):
 
     args = argparser.parse_args(argv)
 
-    if args.action == 'show':
-        show_config(args.config_path)
-    elif args.action == 'set':
-        set_config_value(args.config_path, args.key_path, parse_value(args.value))
-    elif args.action == 'add-item':
-        add_config_value(args.config_path, args.key_path, parse_value(args.value))
-    elif args.action == 'remove-item':
-        remove_config_value(args.config_path, args.key_path, parse_value(args.value))
-    elif args.action == 'reload':
-        reload_component(args.component)
-    else:
-        argparser.print_help()
+    try:
+        if args.action == 'show':
+            show_config(args.config_path)
+        elif args.action == 'set':
+            set_config_value(args.config_path, args.key_path, parse_value(args.value))
+        elif args.action == 'add-item':
+            add_config_value(args.config_path, args.key_path, parse_value(args.value))
+        elif args.action == 'remove-item':
+            remove_config_value(args.config_path, args.key_path, parse_value(args.value))
+        elif args.action == 'reload':
+            reload_component(args.component)
+        else:
+            argparser.print_help()
+    except Exception as e:
+        print(str(e))
+        print("Perhaps you didn't use `sudo -E`?")
 
 
 if __name__ == '__main__':

--- a/tljh/config.py
+++ b/tljh/config.py
@@ -219,6 +219,10 @@ def _is_list(item):
 
 
 def main(argv=None):
+    if os.geteuid() != 0:
+        print("Perhaps you didn't use `sudo -E`?")
+        raise(SystemExit)
+
     if argv is None:
         argv = sys.argv[1:]
 
@@ -295,22 +299,18 @@ def main(argv=None):
 
     args = argparser.parse_args(argv)
 
-    try:
-        if args.action == 'show':
-            show_config(args.config_path)
-        elif args.action == 'set':
-            set_config_value(args.config_path, args.key_path, parse_value(args.value))
-        elif args.action == 'add-item':
-            add_config_value(args.config_path, args.key_path, parse_value(args.value))
-        elif args.action == 'remove-item':
-            remove_config_value(args.config_path, args.key_path, parse_value(args.value))
-        elif args.action == 'reload':
-            reload_component(args.component)
-        else:
-            argparser.print_help()
-    except Exception as e:
-        print(str(e))
-        print("Perhaps you didn't use `sudo -E`?")
+    if args.action == 'show':
+        show_config(args.config_path)
+    elif args.action == 'set':
+        set_config_value(args.config_path, args.key_path, parse_value(args.value))
+    elif args.action == 'add-item':
+        add_config_value(args.config_path, args.key_path, parse_value(args.value))
+    elif args.action == 'remove-item':
+        remove_config_value(args.config_path, args.key_path, parse_value(args.value))
+    elif args.action == 'reload':
+        reload_component(args.component)
+    else:
+        argparser.print_help()
 
 
 if __name__ == '__main__':

--- a/tljh/config.py
+++ b/tljh/config.py
@@ -221,7 +221,6 @@ def _is_list(item):
 def main(argv=None):
     if os.geteuid() != 0:
         print("It looks like this command wasn't run with root privileges. Perhaps you didn't use `sudo -E`?")
-        raise(SystemExit)
 
     if argv is None:
         argv = sys.argv[1:]

--- a/tljh/config.py
+++ b/tljh/config.py
@@ -220,7 +220,7 @@ def _is_list(item):
 
 def main(argv=None):
     if os.geteuid() != 0:
-        print("Perhaps you didn't use `sudo -E`?")
+        print("It looks like this command wasn't run with root privileges. Perhaps you didn't use `sudo -E`?")
         raise(SystemExit)
 
     if argv is None:


### PR DESCRIPTION
There used to be two separate errors that occurred if we run the command without sudo:

[Errno 13] Permission denied: '/opt/tljh/installer.log'
at line 226

And 
[Errno 13] Permission denied: '/opt/tljh/config/config.yaml'
at lines 294-305

Now we print an error and print a message about using 'sudo -E'.

I thought about putting the whole main function into one try-except block, but it seems more appropriate to use two different try-except blocks.

https://github.com/jupyterhub/outreachy/issues/5

closes #120