### PR TITLE
Exit when tljh-config is called as non-root

### DIFF
--- a/tljh/config.py
+++ b/tljh/config.py
@@ -219,7 +219,9 @@ def _is_list(item):
 
 def main(argv=None):
     if os.geteuid() != 0:
-        print("It looks like this command wasn't run with root privileges. Perhaps you didn't use `sudo -E`?")
+        print("tljh-config needs root privileges to run", file=sys.stderr)
+        print("Try using sudo before the tljh-config command you wanted to run", file=sys.stderr)
+        sys.exit(1)
 
     if argv is None:
         argv = sys.argv[1:]


### PR DESCRIPTION
- Previously, we only printed warning and did not exit
- Split the warning over two lines rather than one
- -E is not required for tljh-config anymore (since it is in
  /usr/bin, not /usr/local/bin), so do not ask users to use it.
  https://github.com/jupyterhub/the-littlest-jupyterhub/pull/135
  is the PR that made this change, and changed documentation in
  most places.

Followup #120 
 - [ ] Add tests