### PR TITLE
Adds the universe repository to the used sources

### DIFF
--- a/bootstrap/bootstrap.py
+++ b/bootstrap/bootstrap.py
@@ -66,6 +66,7 @@ def main():
     else:
         logger.info('Setting up hub environment')
         initial_setup = True
+        subprocess.check_output(['add-apt-repository', 'universe'], stderr=subprocess.STDOUT)
         subprocess.check_output(['apt-get', 'update', '--yes'], stderr=subprocess.STDOUT)
         subprocess.check_output(['apt-get', 'install', '--yes', 'python3', 'python3-venv', 'git'], stderr=subprocess.STDOUT)
         logger.info('Installed python & virtual environment')

--- a/bootstrap/bootstrap.py
+++ b/bootstrap/bootstrap.py
@@ -66,6 +66,13 @@ def main():
     else:
         logger.info('Setting up hub environment')
         initial_setup = True
+        # Install software-properties-common, so we can get add-apt-repository
+        # That helps us make sure the universe repository is enabled, since
+        # that's where the python3-pip package lives. In some very minimal base
+        # VM images, it looks like the universe repository is disabled by default,
+        # causing bootstrapping to fail.
+        subprocess.check_output(['apt-get', 'update', '--yes'], stderr=subprocess.STDOUT)
+        subprocess.check_output(['apt-get', 'install', '--yes', 'software-properties-common'], stderr=subprocess.STDOUT)
         subprocess.check_output(['add-apt-repository', 'universe'], stderr=subprocess.STDOUT)
         subprocess.check_output(['apt-get', 'update', '--yes'], stderr=subprocess.STDOUT)
         subprocess.check_output(['apt-get', 'install', '--yes', 'python3', 'python3-venv', 'git'], stderr=subprocess.STDOUT)

--- a/bootstrap/bootstrap.py
+++ b/bootstrap/bootstrap.py
@@ -74,8 +74,14 @@ def main():
         subprocess.check_output(['apt-get', 'update', '--yes'], stderr=subprocess.STDOUT)
         subprocess.check_output(['apt-get', 'install', '--yes', 'software-properties-common'], stderr=subprocess.STDOUT)
         subprocess.check_output(['add-apt-repository', 'universe'], stderr=subprocess.STDOUT)
+
         subprocess.check_output(['apt-get', 'update', '--yes'], stderr=subprocess.STDOUT)
-        subprocess.check_output(['apt-get', 'install', '--yes', 'python3', 'python3-venv', 'git'], stderr=subprocess.STDOUT)
+        subprocess.check_output(['apt-get', 'install', '--yes', 
+            'git',
+            'python3',
+            'python3-venv',
+            'python3-pip'
+        ], stderr=subprocess.STDOUT)
         logger.info('Installed python & virtual environment')
         os.makedirs(hub_prefix, exist_ok=True)
         subprocess.check_output(['python3', '-m', 'venv', hub_prefix], stderr=subprocess.STDOUT)


### PR DESCRIPTION
This change is required, to support Ubuntu Server 18.04.01, which by default doesn't ship with universe. Universe contains python3-venv which is needed for tljh