### PR TITLE
Move custom server troubleshooting code to its own page

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -130,6 +130,7 @@ here to better support your favorite provider!
 
    troubleshooting/providers/google
    troubleshooting/providers/amazon
+   troubleshooting/providers/custom
 
 Contributing
 ============

--- a/docs/install/custom-server.rst
+++ b/docs/install/custom-server.rst
@@ -25,26 +25,14 @@ Pre-requisites
 #. Ability to ``ssh`` into the server & run commands from the prompt.
 #. A **IP address** where the server can be reached from the browsers of your target audience.
 
+If you run into issues, look at the specific :ref:`troubleshooting guide <troubleshooting/providers/custom>`
+for custom server installations.
+
 Step 1: Installing The Littlest JupyterHub
 ==========================================
 
 #. Using a terminal program, SSH into your server. This should give you a prompt where you can
    type commands.
-
-#. If your server is behind a firewall and needs a proxy to reach the internet:
-
-   .. code-block:: bash
-
-      export http_proxy=<your_proxy>
-
-#. Some requests will fail if your certs are self-signed. Copy the text below and paste it
-   into the terminal after replacing ``</directory/with/your/ssl/certificates>`` 
-   with the **path of the directory containing your ssl certificates** (don't include the brackets!).:
-
-   .. code::
-
-      export REQUESTS_CA_BUNDLE=</directory/with/your/ssl/certificates>
-      sudo npm config set cafile=</directory/with/your/ssl/certificates>
 
 #. Make sure you have ``Python3``, ``curl`` and ``git``  installed. On latest Ubuntu you can get all of these with:
 

--- a/docs/troubleshooting/providers/custom.rst
+++ b/docs/troubleshooting/providers/custom.rst
@@ -1,0 +1,30 @@
+.. _troubleshooting/providers/custom:
+
+=========================================
+Troubleshooting issues on your own server
+=========================================
+
+This is an incomplete list of issues people have run into
+when installing TLJH on their own servers, and ways they
+have fixed them.
+
+Outgoing HTTP proxy required
+============================
+If your server is behind a firewall that requires a HTTP proxy to reach
+the internet, run these commands before running the installer
+
+.. code-block:: bash
+
+    export http_proxy=<your_proxy-server>
+
+HTTPS certificate interception
+==============================
+
+If your server is behind a firewall that intercepts HTTPS requests
+and re-signs them, you might have to explicitly tell TLJH which
+certificates to use.
+
+.. code::
+
+    export REQUESTS_CA_BUNDLE=</directory/with/your/ssl/certificates>
+    sudo npm config set cafile=</directory/with/your/ssl/certificates>


### PR DESCRIPTION
Most people won't need to do this, so let's move it
to the troubleshooting page

 - [x] Add / update documentation
 