### PR TITLE
Use newer firstuseauthenticator

### DIFF
--- a/tljh/installer.py
+++ b/tljh/installer.py
@@ -187,7 +187,7 @@ def ensure_jupyterhub_package(prefix):
         'jupyterhub==0.9.4',
         'jupyterhub-dummyauthenticator==0.3.1',
         'jupyterhub-systemdspawner==0.11',
-        'jupyterhub-firstuseauthenticator==0.11',
+        'jupyterhub-firstuseauthenticator==0.12',
         'jupyterhub-ldapauthenticator==1.2.2',
         'oauthenticator==0.8.0',
     ])


### PR DESCRIPTION
This uses v0.12 which allow for deleting users before they have set their password.

 - [ ] Add / update documentation
 - [ ] Add tests

Is any of the above necessary?

 <!-- Read more about our code-review guidelines at https://the-littlest-jupyterhub.readthedocs.io/en/latest/contributing/code-review.html -->