### PR TITLE
DOC: moved nativeauthentic config instructions to code block

### DIFF
--- a/docs/howto/auth/nativeauth.rst
+++ b/docs/howto/auth/nativeauth.rst
@@ -14,7 +14,9 @@ will be authorized automatically.
 Enabling the authenticator
 ==========================
 
-#. Enable the authenticator and reload config to apply the configuration:
+Enable the authenticator and reload config to apply the configuration:
+
+.. code-block:: bash
 
    sudo tljh-config set auth.type nativeauthenticator.NativeAuthenticator
    sudo tljh-config reload


### PR DESCRIPTION
Moved the config to a code block because as rendered, the commands blend and create an error when trying to c&p. Also removed the 1. because there's no 2. Here's as currently rendered in docs:
![image](https://user-images.githubusercontent.com/1300499/54396598-f0725780-4689-11e9-9790-530037efcfa9.png)

And here's the change:
![image](https://user-images.githubusercontent.com/1300499/54396720-5068fe00-468a-11e9-8c94-1d0f387c6a64.png)


 - [ x ] Add / update documentation
 - [ ] Add tests
