### PR TITLE
[MRG] Fix the version tag of the notebook package

### DIFF
--- a/tljh/installer.py
+++ b/tljh/installer.py
@@ -243,7 +243,7 @@ def ensure_user_environment(user_requirements_txt_file):
     conda.ensure_pip_packages(USER_ENV_PREFIX, [
         # JupyterHub + notebook package are base requirements for user environment
         'jupyterhub==0.9.5',
-        'notebook==5.7.7',
+        'notebook==5.7.8',
         # Install additional notebook frontends!
         'jupyterlab==0.35.4',
         'nteract-on-jupyter==2.0.7',


### PR DESCRIPTION
This takes TLJH to notebook 5.7.8. According to PyPI 5.7.7 was never released so I think this fixes typo.