### PR TITLE
adding sidebar links

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,3 +1,3 @@
-div.sphinxsidebarwrapper h1.logo {
-  font-size: 2.3rem;
+div.toctree-wrapper p.caption {
+  display: none;
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,6 +56,7 @@ if os.path.exists(os.path.join(here, '_static')):
 html_sidebars = {
     '**': [
         'about.html',
+        'globaltoc.html',
         'relations.html',
         'searchbox.html',
         'donate.html',
@@ -74,3 +75,6 @@ html_theme_options = {
     'github_banner': False,
     'github_type': 'star',
 }
+
+def setup(app):
+    app.add_stylesheet('custom.css')

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,6 +28,7 @@ We have a bunch of tutorials to get you started.
 
   .. toctree::
      :titlesonly:
+     :caption: Installation
 
      install/digitalocean
      install/jetstream
@@ -48,6 +49,7 @@ Content and Data
 
 .. toctree::
    :titlesonly:
+   :caption: Content and data
 
    howto/content/nbgitpuller
    howto/content/add-data
@@ -58,6 +60,7 @@ The user environment
 
 .. toctree::
    :titlesonly:
+   :caption: The user environment
 
    howto/env/user-environment
    howto/env/notebook-interfaces
@@ -72,6 +75,7 @@ with your JupyterHub. For more information on Authentication, see
 
 .. toctree::
    :titlesonly:
+   :caption: Authentication
 
    howto/auth/dummy
    howto/auth/github
@@ -83,6 +87,7 @@ Administration and security
 
 .. toctree::
    :titlesonly:
+   :caption: Administration and security
 
    howto/admin/admin-users
    howto/admin/resource-estimation
@@ -99,6 +104,7 @@ Topic guides provide in-depth explanations of specific topics.
 
 .. toctree::
    :titlesonly:
+   :caption: Topic guides
 
    topic/whentouse
    topic/requirements
@@ -118,6 +124,7 @@ guides help you find what is broken & hopefully fix it.
 
 .. toctree::
    :titlesonly:
+   :caption: Troubleshooting
 
    troubleshooting/logs
 
@@ -142,6 +149,7 @@ to people contributing in various ways.
 
 .. toctree::
    :titlesonly:
+   :caption: Contributing
 
    contributing/docs
    contributing/code-review


### PR DESCRIPTION
 - [x] Add / update documentation

This does a couple things:

1. Adds sidebar links for the table of contents, so you can navigate to other pages from within sub-pages
2. Adds captions to the toctrees, so that there are headers in the sidebar links
3. Adds css to make the within-page captions invisible because we're already using headers for this instead of captions

curious what @yuvipanda or @leportella think about this!