### PR TITLE
Update Readme for the AWS docs link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ Ubuntu 18.04. We have a bunch of tutorials to get you started!
   - `Digital Ocean <https://the-littlest-jupyterhub.readthedocs.io/en/latest/install/digitalocean.html>`_
   - `Google Cloud <https://the-littlest-jupyterhub.readthedocs.io/en/latest/install/google.html>`_
   - `Jetstream <https://the-littlest-jupyterhub.readthedocs.io/en/latest/install/jetstream.html>`_
-  - `Amazon Web Services <https://aws.amazon.com/>`_
+  - `Amazon Web Services <https://the-littlest-jupyterhub.readthedocs.io/en/latest/install/amazon.html>`_
   - ... your favorite provider here, if you can contribute!
 
 - `Tutorial to install TLJH on an already running server you have root access to


### PR DESCRIPTION
Fixed the link for AWS docs to point to the right location.

 - [x] Add / update documentation
 - [ ] Add tests

 <!-- Read more about our code-review guidelines at https://the-littlest-jupyterhub.readthedocs.io/en/latest/contributing/code-review.html -->