### PR TITLE
Move digital ocean 'resize' docs out of 'install' step

### DIFF
--- a/docs/howto/admin/resize.rst
+++ b/docs/howto/admin/resize.rst
@@ -13,12 +13,10 @@ the cloud provider of your choice.
 
 Currently there are instructions to resize your resources on the following providers:
 
-* :ref:`Digital Ocean <digitalocean/resize>`.
+* :ref:`Digital Ocean <howto/providers/digitalocean/resize>`.
 
 Once resources have been reallocated, you must tell TLJH to make use of these resources,
 and verify that the resources have become available.
-
-.. _tljhconf:
 
 Verifying a Resize 
 ==================

--- a/docs/howto/providers/digitalocean.rst
+++ b/docs/howto/providers/digitalocean.rst
@@ -1,0 +1,43 @@
+.. _howto/providers/digitalocean:
+
+================================================
+Perform common Digital Ocean configuration tasks
+================================================
+
+This page lists various common tasks you can perform on your
+Digital Ocean virtual machine.
+
+.. _howto/providers/digitalocean/resize:
+
+Resizing your droplet
+=====================
+
+As you use your JupyterHub, you may find that you need more memory, 
+disk space, or CPUs. Digital Ocean servers can be resized in the 
+"Resize Droplet" panel. These instructions take you through the process.
+
+#. First, click on the name of your newly-created
+   Droplet to enter its configuration page.
+
+#. Next, **turn off your Droplet**. This allows DigitalOcean to make
+   modifications to your VM. This will shut down your JupyterHub (temporarily).
+
+   .. image:: ../../images/providers/digitalocean/power-off.png
+      :alt: Power off your Droplet
+      :width: 200px
+
+#. Once your Droplet has been turned off, click "Resize",
+   which will take you to a menu with options to resize your VM.
+
+   .. image:: ../../images/providers/digitalocean/resize-droplet.png
+      :alt: Resize panel of digital ocean
+
+#. Decide what kinds of resources you'd like to resize, then click on a new VM
+   type in the list below. Finally, click "Resize". This may take a few moments!
+
+#. Once your Droplet is resized, **turn your Droplet back on**. This makes your JupyterHub
+   available to the world once again. This will take a few moments to complete.
+
+Now that you've resized your Droplet, you may want to change the resources available
+to your users. Further information on making more resources available to
+users and verifying resource availability can be found in :ref:`howto/admin/resize`. 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -96,6 +96,14 @@ Administration and security
    howto/admin/https
    howto/admin/enable-extensions
 
+Cloud provider configuration
+----------------------------
+
+.. toctree::
+   :titlesonly:
+   :caption: Cloud provider configuration
+
+   howto/providers/digitalocean
 
 Topic Guides
 ============

--- a/docs/install/digitalocean.rst
+++ b/docs/install/digitalocean.rst
@@ -117,39 +117,3 @@ Step 3: Install conda / pip packages for all users
 ==================================================
 
 .. include:: add_packages.txt
-
-.. _digitalocean/resize:
-
-Step 4: Resizing and editing the droplet
-========================================
-
-As you use your JupyterHub, you may find that you need more memory, 
-disk space, or CPUs. Digital Ocean servers can be resized in the 
-"Resize Droplet" panel. These instructions take you through the process.
-
-#. First, click on the name of your newly-created
-   Droplet to enter its configuration page.
-
-#. Next, **turn off your Droplet**. This allows DigitalOcean to make
-   modifications to your VM. This will shut down your JupyterHub (temporarily).
-
-   .. image:: ../images/providers/digitalocean/power-off.png
-      :alt: Power off your Droplet
-      :width: 200px
-
-#. Once your Droplet has been turned off, click "Resize",
-   which will take you to a menu with options to resize your VM.
-
-   .. image:: ../images/providers/digitalocean/resize-droplet.png
-      :alt: Resize panel of digital ocean
-
-#. Decide what kinds of resources you'd like to resize, then click on a new VM
-   type in the list below. Finally, click "Resize". This may take a few moments!
-
-#. Once your Droplet is resized, **turn your Droplet back on**. This makes your JupyterHub
-   available to the world once again. This will take a few moments to complete.
-
-Now that you've resized your Droplet, you may want to change the resources available
-to your users. Further information on making more resources available to
-users and verifying resource availability can be found in :ref:`howto/admin/resize`. 
-


### PR DESCRIPTION
Since you usually don't want to resize right after you
create a VM, I've moved it to a more central 'cloud provider
tasks' page. We can add additional things here too. It
matches similar provider specific pages we have for
troubleshooting

 - [x] Add / update documentation
