### PR TITLE
Use c.Spawner to set mem_limit & cpu_limit

### DIFF
--- a/tests/test_configurer.py
+++ b/tests/test_configurer.py
@@ -66,7 +66,7 @@ def test_default_memory_limit():
     Test default per user memory limit
     """
     c = apply_mock_config({})
-    assert c.SystemdSpawner.mem_limit is None
+    assert c.Spawner.mem_limit is None
 
 
 def test_set_memory_limit():
@@ -74,7 +74,7 @@ def test_set_memory_limit():
     Test setting per user memory limit
     """
     c = apply_mock_config({'limits': {'memory': '42G'}})
-    assert c.SystemdSpawner.mem_limit == '42G'
+    assert c.Spawner.mem_limit == '42G'
 
 
 def test_app_default():

--- a/tljh/configurer.py
+++ b/tljh/configurer.py
@@ -162,8 +162,8 @@ def update_limits(c, config):
     """
     limits = config['limits']
 
-    c.SystemdSpawner.mem_limit = limits['memory']
-    c.SystemdSpawner.cpu_limit = limits['cpu']
+    c.Spawner.mem_limit = limits['memory']
+    c.Spawner.cpu_limit = limits['cpu']
 
 
 def update_user_environment(c, config):


### PR DESCRIPTION
mem_limit & cpu_limit are traitlets on the parent
Spawner class. Setting these here allows plugins to
do the dangerous job of swapping the SystemdSpawner
out for something else
