### PR TITLE
Limit memory available in integration tests

### DIFF
--- a/.circleci/integration-test.py
+++ b/.circleci/integration-test.py
@@ -29,6 +29,7 @@ def run_systemd_image(image_name, container_name):
         '--mount', 'type=bind,source=/sys/fs/cgroup,target=/sys/fs/cgroup',
         '--detach',
         '--name', container_name,
+        '--memory', '512M', # This is the minimum VM size we support
         image_name
     ])
 

--- a/.circleci/integration-test.py
+++ b/.circleci/integration-test.py
@@ -29,7 +29,10 @@ def run_systemd_image(image_name, container_name):
         '--mount', 'type=bind,source=/sys/fs/cgroup,target=/sys/fs/cgroup',
         '--detach',
         '--name', container_name,
-        '--memory', '768M', # This is the minimum VM size we support
+        # This is the minimum VM size we support. JupyterLab extensions seem
+        # to need at least this much RAM to build. Boo?
+        # If we change this, need to change all other references to this number.
+        '--memory', '768M',
         image_name
     ])
 

--- a/.circleci/integration-test.py
+++ b/.circleci/integration-test.py
@@ -29,7 +29,7 @@ def run_systemd_image(image_name, container_name):
         '--mount', 'type=bind,source=/sys/fs/cgroup,target=/sys/fs/cgroup',
         '--detach',
         '--name', container_name,
-        '--memory', '512M', # This is the minimum VM size we support
+        '--memory', '768M', # This is the minimum VM size we support
         image_name
     ])
 

--- a/docs/howto/admin/resource-estimation.rst
+++ b/docs/howto/admin/resource-estimation.rst
@@ -12,7 +12,8 @@ Memory
 ======
 
 Memory is usually the biggest determinant of server size in most JupyterHub
-installations.
+installations. At minimum, your server must have at least **768MB** of RAM
+for TLJH to install.
 
 .. math::
 

--- a/docs/install/amazon.rst
+++ b/docs/install/amazon.rst
@@ -78,7 +78,8 @@ Let's create the server on which we can run JupyterHub.
    `Next: Configure Instance Details` in the lower right corner.  
    
    Check out our guide on How To :ref:`howto/admin/resource-estimation` to help pick
-   how much Memory / CPU your server needs.
+   how much Memory / CPU your server needs. You need to have at least **768MB** of
+   RAM.
    
    You may wish to consult the listing `here <https://www.ec2instances.info/>`_ 
    because it shows cost per hour. The **On Demand** price is the pertinent cost.

--- a/docs/install/custom-server.rst
+++ b/docs/install/custom-server.rst
@@ -22,6 +22,7 @@ Pre-requisites
 
 #. Some familiarity with the command line.
 #. A server running Ubuntu 18.04 where you have root access.
+#. At least **768MB** of RAM on your server.
 #. Ability to ``ssh`` into the server & run commands from the prompt.
 #. A **IP address** where the server can be reached from the browsers of your target audience.
 

--- a/docs/install/google.rst
+++ b/docs/install/google.rst
@@ -69,7 +69,7 @@ Let's create the server on which we can run JupyterHub.
 #. For **Zone**, pick any of the options. Leaving the default as is is fine.
 
 #. Under **Machine** type, select the amount of CPU / RAM / GPU you want for your
-   server.
+   server. You need at least **768MB** of RAM.
 
    You can select a preset combination in the default **basic view**.
 

--- a/docs/install/jetstream.rst
+++ b/docs/install/jetstream.rst
@@ -53,6 +53,7 @@ Let's create the server on which we can run JupyterHub.
 
    #. Give your server a descriptive **Instance Name**.
    #. Select an appropriate **Instance Size**. We suggest m1.medium or larger.
+      Make sure your instance has at least **768MB** of RAM.
 
       Check out our guide on How To :ref:`howto/admin/resource-estimation` to help pick
       how much Memory, CPU & disk space your server needs.


### PR DESCRIPTION
- Run all integration tests with a 768MB memory limit,
  so we know when we're using too much RAM
- Document this memory requirement in our docs.

Fixes #257

 - [x] Add / update documentation
 - [x] Add tests