### PR TITLE
Add "tljh-config unset" option

### DIFF
--- a/docs/topic/tljh-config.rst
+++ b/docs/topic/tljh-config.rst
@@ -22,8 +22,8 @@ You can run ``tljh-config`` in two ways:
 .. _tljh-set:
 
 
-Set a configuration property
-============================
+Set / Unset a configuration property
+====================================
 
 TLJH's configuration is organized in a nested tree structure. You can
 set a particular property with the following command:
@@ -49,6 +49,17 @@ do so with the following:
 
 
 This can only set string and numerical properties, not lists.
+
+To unset a configuration property you can use the following command:
+
+.. code-block:: bash
+
+   sudo tljh-config unset <property-path>
+
+Unsetting a configuration property removes the property from the configuration
+file. If what you want is only to change the property's value, you should use
+``set`` and overwrite it with the desired value.
+
 
 Some of the existing ``<property-path>`` are listed below by categories:
 


### PR DESCRIPTION
 - [x] Add / update documentation
 - [x] Add tests

closes https://github.com/jupyterhub/the-littlest-jupyterhub/issues/203

I added the option to unset (remove) a config property. @yuvipanda, I'm not sure if this is wanted but I thought it would be nice to be able to remove a config property the same way we're setting it, without editing the config file.
 <!-- Read more about our code-review guidelines at https://the-littlest-jupyterhub.readthedocs.io/en/latest/contributing/code-review.html -->