### PR TITLE
Fixed out of date config directory listed in docs for tljh-config

### DIFF
--- a/docs/topic/tljh-config.rst
+++ b/docs/topic/tljh-config.rst
@@ -168,6 +168,6 @@ Advanced: ``config.yaml``
 =========================
 
 ``tljh-config`` is a simple program that modifies the contents of the
-``config.yaml`` file located at ``/opt/tljh/config.yaml``. ``tljh-config``
+``config.yaml`` file located at ``/opt/tljh/config/config.yaml``. ``tljh-config``
 is the recommended method of editing / viewing configuration since editing
 YAML by hand in a terminal text editor is a large source of errors.


### PR DESCRIPTION
Fixed the problem docs for tljh-config incorrectly listing the location of the config.yaml file (Issue #354).

 - [X] Add / update documentation
 - [ ] Add tests

 <!-- Read more about our code-review guidelines at https://the-littlest-jupyterhub.readthedocs.io/en/latest/contributing/code-review.html -->