### PR TITLE
Minor azure doc cleanup

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,6 +44,7 @@ Ubuntu 18.04. We have a bunch of tutorials to get you started!
   - `Google Cloud <https://the-littlest-jupyterhub.readthedocs.io/en/latest/install/google.html>`_
   - `Jetstream <https://the-littlest-jupyterhub.readthedocs.io/en/latest/install/jetstream.html>`_
   - `Amazon Web Services <https://the-littlest-jupyterhub.readthedocs.io/en/latest/install/amazon.html>`_
+  - `Microsoft Azure<https://the-littlest-jupyterhub.readthedocs.io/en/latest/install/azure.html>`_
   - ... your favorite provider here, if you can contribute!
 
 - `Tutorial to install TLJH on an already running server you have root access to

--- a/docs/howto/providers/azure.rst
+++ b/docs/howto/providers/azure.rst
@@ -1,3 +1,13 @@
+.. _howto/providers/azure:
+
+==================================================
+Perform common Microsoft Azure configuration tasks
+==================================================
+
+This page lists various common tasks you can perform on your
+Microsoft Azure virtual machine.
+
+.. _howto/providers/azure/resize:
 
 Deleting or stopping your virtual machine
 ===========================================

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -33,8 +33,8 @@ We have a bunch of tutorials to get you started.
      install/jetstream
      install/google
      install/amazon
-     install/custom-server
      install/azure
+     install/custom-server
 
 Once you are ready to run your server for real,
 it's a good idea to proceed directly to :doc:`howto/admin/https`.


### PR DESCRIPTION
- Change title of azure config howto
- Link to azure docs from README
- Keep all the cloud provider links together in the
  documentation index

 - [x] Add / update documentation
