### PR TITLE
Add tmpauthenticator by default to TLJH

### DIFF
--- a/docs/topic/authenticator-configuration.rst
+++ b/docs/topic/authenticator-configuration.rst
@@ -16,6 +16,8 @@ can be used with TLJH. A number of them ship by default with TLJH:
    available.
 #. `FirstUseAuthenticator <https://github.com/yuvipanda/jupyterhub-firstuseauthenticator>`_ - Users set
    their password when they log in for the first time. Default authenticator used in TLJH.
+#. `TmpAuthenticator <https://github.com/jupyterhub/tmpauthenticator>`_ - Opens the JupyterHub to the
+   world, makes a new user every time someone logs in.
 #. `NativeAuthenticator <https://native-authenticator.readthedocs.io/en/latest/>`_ - Allow users to signup, add password security verification and block users after failed attempts oflogin. 
 
 We try to have specific how-to guides & tutorials for common authenticators. Since we can not cover

--- a/tljh/installer.py
+++ b/tljh/installer.py
@@ -208,6 +208,7 @@ def ensure_jupyterhub_package(prefix):
         'jupyterhub-firstuseauthenticator==0.12',
         'jupyterhub-nativeauthenticator==0.0.4',
         'jupyterhub-ldapauthenticator==1.2.2',
+        'jupyterhub-tmpauthenticator==0.6',
         'oauthenticator==0.8.2',
     ])
     traefik.ensure_traefik_binary(prefix)


### PR DESCRIPTION
Is popular enough we should let people use it by
default

 - [x] Add tests

 <!-- Read more about our code-review guidelines at https://the-littlest-jupyterhub.readthedocs.io/en/latest/contributing/code-review.html -->