### PR TITLE
Fix typo in README link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ Ubuntu 18.04. We have a bunch of tutorials to get you started!
   - `Google Cloud <https://the-littlest-jupyterhub.readthedocs.io/en/latest/install/google.html>`_
   - `Jetstream <https://the-littlest-jupyterhub.readthedocs.io/en/latest/install/jetstream.html>`_
   - `Amazon Web Services <https://the-littlest-jupyterhub.readthedocs.io/en/latest/install/amazon.html>`_
-  - `Microsoft Azure<https://the-littlest-jupyterhub.readthedocs.io/en/latest/install/azure.html>`_
+  - `Microsoft Azure <https://the-littlest-jupyterhub.readthedocs.io/en/latest/install/azure.html>`_
   - ... your favorite provider here, if you can contribute!
 
 - `Tutorial to install TLJH on an already running server you have root access to


### PR DESCRIPTION
This PR fixes the typesetting of the Azure link in the README. 

Before:

<img width="764" alt="Screenshot 2019-06-10 at 07 41 31" src="https://user-images.githubusercontent.com/1392879/59177181-3177ec00-8b53-11e9-8f9f-ecade5085e29.png">

After:

<img width="307" alt="Screenshot 2019-06-10 at 07 42 17" src="https://user-images.githubusercontent.com/1392879/59177211-494f7000-8b53-11e9-86e3-428953d1d3e4.png">
