### PR TITLE
Fix typo: missing "c" for instance

### DIFF
--- a/docs/install/ovh.rst
+++ b/docs/install/ovh.rst
@@ -86,7 +86,7 @@ Let's create the server on which we can run JupyterHub.
 
 #. Select a billing period: monthly or hourly.
 
-#. Click the **Create an instane** button! You will be taken to a different screen,
+#. Click the **Create an instance** button! You will be taken to a different screen,
    where you can see progress of your server being created.
 
    .. image:: ../images/providers/ovh/create-instance.png


### PR DESCRIPTION
For the OVH guide.

 - [x] Add / update documentation
 - [x] ~Add tests~
