### PR TITLE
Test TLJH against 19.04

### DIFF
--- a/integration-tests/Dockerfile
+++ b/integration-tests/Dockerfile
@@ -1,5 +1,6 @@
 # Systemd inside a Docker container, for CI only
-FROM ubuntu:18.04
+ARG UBUNTU_VERSION=19.04
+FROM ubuntu:${UBUNTU_VERSION}
 
 RUN apt-get update --yes
 


### PR DESCRIPTION
It might be useful to test against latest LTS
as well as latest Ubuntu. This makes life easier
when we wanna update to new LTS, and provides
an option for people who want more recent package
versions

 - [ ] Add / update documentation
 - [ ] Add tests

TODO:
- [ ] Don't stop testing 18.04
- [ ] Document that you can run this on 19.04, and why you would
 <!-- Read more about our code-review guidelines at https://the-littlest-jupyterhub.readthedocs.io/en/latest/contributing/code-review.html -->