### PR TITLE
Replace pre-alpha by beta state in documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,16 +25,16 @@ more information.
 Development Status
 ==================
 
-This project is currently in **alpha** state. Most things work, but we might
-still make breaking changes that have no clear upgrade pathway. We are targeting
-a v0.1 release sometime in mid-August 2018. Follow `this milestone <https://github.com/jupyterhub/the-littlest-jupyterhub/milestone/1>`_
-to see progress towards the release!
+This project is currently in **beta** state. Folks have been using installations
+of TLJH for more than a year now to great success. While we try hard not to, we
+might still make breaking changes that have no clear upgrade pathway.
 
 Installation
 ============
 
 The Littlest JupyterHub (TLJH) can run on any server that is running at least
-Ubuntu 18.04. We have a bunch of tutorials to get you started!
+**Ubuntu 18.04**. Earlier versions of Ubuntu are not supported.
+We have a bunch of tutorials to get you started.
 
 - Tutorials to create a new server from scratch on a cloud provider & run TLJH
   on it. These are **recommended** if you do not have much experience setting up

--- a/docs/topic/security.rst
+++ b/docs/topic/security.rst
@@ -2,9 +2,9 @@
 Security Considerations
 =======================
 
-The Littlest JupyterHub is in pre-alpha state & should not be used in
-security critical situations. We will try to keep things as secure as possible,
-but sometimes trade security for massive gains in convenience. This page contains
+The Littlest JupyterHub is in beta state & should not be used in security
+critical situations. We will try to keep things as secure as possible, but
+sometimes trade security for massive gains in convenience. This page contains
 information about the security model of The Littlest JupyterHub.
 
 System user accounts


### PR DESCRIPTION
According to 3af53522, TLJH is in beta state by now. This commit
replaces the other occurrences in the documentation to make it
consistent. Also syncs other paragraphs from index.rst to README.rst,
see 5374f5ea.