### PR TITLE
Run idle culler as a python module

### DIFF
--- a/tests/test_configurer.py
+++ b/tests/test_configurer.py
@@ -195,7 +195,7 @@ def test_cull_service_default():
     c = apply_mock_config({})
 
     cull_cmd = [
-       sys.executable, '/srv/src/tljh/cull_idle_servers.py',
+       sys.executable, '-m', 'tljh.cull_idle_servers',
        '--timeout=600', '--cull-every=60', '--concurrency=5',
        '--max-age=0'
     ]
@@ -220,7 +220,7 @@ def test_set_cull_service():
         }
     })
     cull_cmd = [
-       sys.executable, '/srv/src/tljh/cull_idle_servers.py',
+       sys.executable, '-m', 'tljh.cull_idle_servers',
        '--timeout=600', '--cull-every=10', '--concurrency=5',
        '--max-age=60', '--cull-users'
     ]

--- a/tljh/configurer.py
+++ b/tljh/configurer.py
@@ -208,7 +208,7 @@ def set_cull_idle_service(config):
     Set Idle Culler service
     """
     cull_cmd = [
-       sys.executable, '/srv/src/tljh/cull_idle_servers.py'
+       sys.executable, '-m', 'tljh.cull_idle_servers'
     ]
     cull_config = config['services']['cull']
     print()


### PR DESCRIPTION
Regarding https://github.com/jupyterhub/the-littlest-jupyterhub/issues/384, this PR removes the hard-coded path of the idle culler and runs the script as a python module.

 <!-- Read more about our code-review guidelines at https://the-littlest-jupyterhub.readthedocs.io/en/latest/contributing/code-review.html -->