### PR TITLE
Fix link to the hooks in plugins docs

### DIFF
--- a/docs/contributing/plugins.rst
+++ b/docs/contributing/plugins.rst
@@ -88,7 +88,7 @@ A hook implementation is a function that has the following characteristics:
    ``tljh.hooks``.
 
 The current list of available hooks and when they are called can be
-seen in ```tljh/hooks.py`` <https://github.com/jupyterhub/the-littlest-jupyterhub/blob/master/tljh/hooks.py>`_
+seen in `tljh/hooks.py <https://github.com/jupyterhub/the-littlest-jupyterhub/blob/master/tljh/hooks.py>`_
 in the source repository.
 
 


### PR DESCRIPTION
Fix the rendering of the link to the plugins hooks in the documentation.

 - [x] Add / update documentation
 - [ ] Add tests

### Before

![image](https://user-images.githubusercontent.com/591645/60256490-ed664480-98d1-11e9-8775-3a5638aa772f.png)

### After

![image](https://user-images.githubusercontent.com/591645/60256469-e17a8280-98d1-11e9-8bee-0133d8122acf.png)
