### PR TITLE
Set admin password during install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,6 +73,12 @@ jobs:
                     .circleci/integration-test.py run-test basic-tests test_hub.py test_install.py test_extensions.py
 
             - run:
+                name: Run admin tests
+                command: |
+                    .circleci/integration-test.py run-test --installer-args "--admin admin:admin" basic-tests test_admin_installer.py
+
+
+            - run:
                 name: Run plugin tests
                 command: |
                     .circleci/integration-test.py run-test \

--- a/docs/contributing/dev-setup.rst
+++ b/docs/contributing/dev-setup.rst
@@ -43,6 +43,14 @@ The easiest & safest way to develop & test TLJH is with `Docker <https://www.doc
 
       python3 /srv/src/bootstrap/bootstrap.py --admin admin
 
+  Or, if you would like to setup the admin's password during install,
+  you can use this command (replace "admin" with the desired admin username
+  and "password" with the desired admin password):
+
+   .. code-block:: console
+
+      python3 /srv/src/bootstrap/bootstrap.py --admin admin:password
+
    The primary hub environment will also be in your PATH already for convenience.
 
 #. You should be able to access the JupyterHub from your browser now at

--- a/docs/howto/admin/admin-users.rst
+++ b/docs/howto/admin/admin-users.rst
@@ -19,7 +19,8 @@ so attackers can not easily gain control of the system.
 .. important::
 
    You should make sure an admin user is present when you **install** TLJH
-   the very first time. The ``:ref:`--admin <topic/customizing-installer/admin>```
+   the very first time. It is recommended that you also set a password
+   for the admin at this step. The :ref:`--admin <topic/customizing-installer/admin>`
    flag passed to the installer does this. If you had forgotten to do so, the
    easiest way to fix this is to run the installer again.
 

--- a/docs/topic/customizing-installer.rst
+++ b/docs/topic/customizing-installer.rst
@@ -20,17 +20,38 @@ This page documents the various options you can pass as commandline parameters t
 Adding admin users
 ===================
 
-``--admin <username>`` adds user ``<username>`` to JupyterHub as an admin user.
-This can be repeated multiple times.
+``--admin <username>:<password>`` adds user ``<username>`` to JupyterHub as an admin user
+and sets its password to be ``<password>``.
+Although it is not recommended, it is possible to only set the admin username at this point
+and set the admin password after the installation.
 
-For example, to add ``admin-user1`` and ``admin-user2`` as admins when installing, you
-would do:
+Also, the ``--admin`` flag can be repeated multiple times. For example, to add ``admin-user1``
+and ``admin-user2`` as admins when installing, depending if you would like to set their passwords
+during install you would:
+
+* set ``admin-user1`` with password ``password-user1`` and ``admin-user2`` with ``password-user2`` using:
+
+.. code-block:: bash
+
+    curl https://raw.githubusercontent.com/jupyterhub/the-littlest-jupyterhub/master/bootstrap/bootstrap.py \
+     | sudo python3 - \
+       --admin admin-user1:password-user1 --admin admin-user2:password-user2
+
+* set ``admin-user1`` and ``admin-user2`` to be admins, without any passwords at this stage, using:
 
 .. code-block:: bash
 
     curl https://raw.githubusercontent.com/jupyterhub/the-littlest-jupyterhub/master/bootstrap/bootstrap.py \
      | sudo python3 - \
        --admin admin-user1 --admin admin-user2
+
+* set ``admin-user1`` with password ``password-user1`` and ``admin-user2`` with no password at this stage using:
+
+.. code-block:: bash
+
+    curl https://raw.githubusercontent.com/jupyterhub/the-littlest-jupyterhub/master/bootstrap/bootstrap.py \
+     | sudo python3 - \
+       --admin admin-user1:password-user1 --admin admin-user2
 
 Installing python packages in the user environment
 ==================================================

--- a/integration-tests/test_admin_installer.py
+++ b/integration-tests/test_admin_installer.py
@@ -1,0 +1,45 @@
+from hubtraf.user import User
+from hubtraf.auth.dummy import login_dummy
+import pytest
+from functools import partial
+import asyncio
+
+
+@pytest.mark.asyncio
+async def test_admin_login():
+    """
+    Test if the admin that was added during install can login with
+    the password provided.
+    """
+    hub_url = 'http://localhost'
+    username = "admin"
+    password = "admin"
+
+    async with User(username, hub_url, partial(login_dummy, password=password)) as u:
+            await u.login()
+            await u.ensure_server()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "username, password",
+    [
+        ("admin", ""),
+        ("admin", "wrong_passw"),
+        ("user", "password"),
+    ],
+)
+async def test_unsuccessful_login(username, password):
+    """
+    Ensure nobody but the admin that was added during install can login
+    """
+    hub_url = 'http://localhost'
+
+    try:
+        async with User(username, hub_url, partial(login_dummy, password="")) as u:
+                await u.login()
+    except Exception:
+        # This is what we except to happen
+        pass
+    else:
+        raise

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
         'passlib',
         'backoff',
         'requests',
+        'bcrypt',
         'jupyterhub-traefik-proxy==0.1.*'
     ],
     entry_points={

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -2,6 +2,7 @@
 Unit test  functions in installer.py
 """
 import os
+import pytest
 
 from tljh import installer
 from tljh.yaml import yaml
@@ -21,10 +22,17 @@ def test_ensure_config_yaml(tljh_dir):
     # verify that old config doesn't exist
     assert not os.path.exists(os.path.join(tljh_dir, 'config.yaml'))
 
-def test_ensure_admins(tljh_dir):
+
+@pytest.mark.parametrize(
+	"admins, expected_config",
+	[
+		([['a1'], ['a2'], ['a3']], ['a1', 'a2', 'a3']),
+		([['a1:p1'], ['a2']], ['a1', 'a2']),
+	],
+)
+def test_ensure_admins(tljh_dir, admins, expected_config):
 	# --admin option called multiple times on the installer
 	# creates a list of argument lists.
-	admins = [['a1'], ['a2'], ['a3']]
 	installer.ensure_admins(admins)
 
 	config_path = installer.CONFIG_FILE
@@ -32,4 +40,4 @@ def test_ensure_admins(tljh_dir):
 	    config = yaml.load(f)
 
 	# verify the list was flattened
-	assert config['users']['admin'] == ['a1', 'a2', 'a3']
+	assert config['users']['admin'] == expected_config

--- a/tljh/installer.py
+++ b/tljh/installer.py
@@ -476,9 +476,7 @@ def main():
     pm = setup_plugins(args.plugin)
 
     ensure_config_yaml(pm)
-
     ensure_admins(args.admin)
-
     ensure_usergroups()
     ensure_user_environment(args.user_requirements_txt_url)
 

--- a/tljh/installer.py
+++ b/tljh/installer.py
@@ -129,8 +129,6 @@ def ensure_jupyterhub_service(prefix):
     Ensure JupyterHub Services are set up properly
     """
 
-    os.makedirs(STATE_DIR, mode=0o700, exist_ok=True)
-
     remove_chp()
     systemd.reload_daemon()
 
@@ -278,6 +276,8 @@ def ensure_admins(admin_password_list):
     """
     Setup given list of users as admins.
     """
+    os.makedirs(STATE_DIR, mode=0o700, exist_ok=True)
+
     if not admin_password_list:
         return
     logger.info("Setting up admin users")
@@ -293,8 +293,8 @@ def ensure_admins(admin_password_list):
     db_passw = os.path.join(STATE_DIR, 'passwords.dbm')
 
     admins = []
-    for i in range(len(admin_password_list)):
-        for admin_password_pair in admin_password_list[i]:
+    for admin_password_entry in admin_password_list:
+        for admin_password_pair in admin_password_entry:
             if ":" in admin_password_pair:
                 admin, password = admin_password_pair.split(':')
                 admins.append(admin)

--- a/tljh/installer.py
+++ b/tljh/installer.py
@@ -467,7 +467,7 @@ def main():
     argparser.add_argument(
         '--password',
         action='store_true',
-        help='List of admin passwords'
+        help='Whether or not to set admin passwords during install'
     )
 
     args = argparser.parse_args()


### PR DESCRIPTION
 Added the option to set the admin user password during install (closes https://github.com/jupyterhub/the-littlest-jupyterhub/issues/263).

If the installer is called with *--password* option, then a password will be requested for each admin user specified with *--admin**. If *--password* is not present, the script will behave like before.

@yuvipanda, can you please give me some advice about how/if should I test this? :eyes: 
 <!-- Read more about our code-review guidelines at https://the-littlest-jupyterhub.readthedocs.io/en/latest/contributing/code-review.html -->