### PR TITLE
Allow adding multiple admins during install 

### DIFF
--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -4,6 +4,7 @@ Unit test  functions in installer.py
 import os
 
 from tljh import installer
+from tljh.yaml import yaml
 
 
 def test_ensure_node():
@@ -19,3 +20,16 @@ def test_ensure_config_yaml(tljh_dir):
     assert os.path.isdir(os.path.join(installer.CONFIG_DIR, 'jupyterhub_config.d'))
     # verify that old config doesn't exist
     assert not os.path.exists(os.path.join(tljh_dir, 'config.yaml'))
+
+def test_ensure_admins(tljh_dir):
+	# --admin option called multiple times on the installer
+	# creates a list of argument lists.
+	admins = [['a1'], ['a2'], ['a3']]
+	installer.ensure_admins(admins)
+
+	config_path = installer.CONFIG_FILE
+	with open(config_path, 'r') as f:
+	    config = yaml.load(f)
+
+	# verify the list was flattened
+	assert config['users']['admin'] == ['a1', 'a2', 'a3']

--- a/tljh/installer.py
+++ b/tljh/installer.py
@@ -286,7 +286,9 @@ def ensure_admins(admins):
         config = {}
 
     config['users'] = config.get('users', {})
-    config['users']['admin'] = list(admins)
+    # Flatten admin lists
+    config['users']['admin'] = [admin for admin_sublist in admins
+        for admin in admin_sublist]
 
     with open(config_path, 'w+') as f:
         yaml.dump(config, f)
@@ -440,6 +442,7 @@ def main():
     argparser.add_argument(
         '--admin',
         nargs='*',
+        action='append',
         help='List of usernames set to be admin'
     )
     argparser.add_argument(


### PR DESCRIPTION
 Added the *append* action to the *--admin* option.