### PR TITLE
Docs update: reload proxy after modifying the ports

### DIFF
--- a/docs/howto/auth/github.rst
+++ b/docs/howto/auth/github.rst
@@ -76,7 +76,7 @@ For more information on ``tljh-config``, see :ref:`topic/tljh-config`.
      sudo tljh-config reload
 
 Confirm that the new authenticator works
-=======================================
+========================================
 
 #. **Open an incognito window** in your browser (do not log out until you confirm
    that the new authentication method works!)

--- a/docs/howto/auth/github.rst
+++ b/docs/howto/auth/github.rst
@@ -75,7 +75,7 @@ For more information on ``tljh-config``, see :ref:`topic/tljh-config`.
 
      sudo tljh-config reload
 
-Confirm that the new authentactor works
+Confirm that the new authenticator works
 =======================================
 
 #. **Open an incognito window** in your browser (do not log out until you confirm

--- a/docs/topic/tljh-config.rst
+++ b/docs/topic/tljh-config.rst
@@ -88,6 +88,7 @@ Ports
 
     sudo tljh-config set http.port 8080
     sudo tljh-config set https.port 8443
+    sudo tljh-config reload proxy
 
 .. _tljh-set-user-lists:
 


### PR DESCRIPTION
Related to https://github.com/jupyterhub/the-littlest-jupyterhub/issues/402, it think we should make it clear that if the http/https ports are changed, the proxy should be reloaded.
 
- [x] Add / update documentation