### PR TITLE
Fix failing conda tests

### DIFF
--- a/tests/test_conda.py
+++ b/tests/test_conda.py
@@ -18,6 +18,9 @@ def prefix():
     with tempfile.TemporaryDirectory() as tmpdir:
         with conda.download_miniconda_installer(miniconda_version, miniconda_installer_md5) as installer_path:
             conda.install_miniconda(installer_path, tmpdir)
+        conda.ensure_conda_packages(tmpdir, [
+            'conda==4.5.8'
+        ])
         yield tmpdir
 
 


### PR DESCRIPTION
The tests are failing for some time :( However, the strange thing is that the tests in *test_conda.py* all pass if ran individually. 

At first I thought this might be related to the newer version of pytest (since the tests passed if each of it got its own instance of the `prefix` fixture). But there wasn't any pytest change to justify the behavior.

After more digging, the issue I noticed is that after the first ``conda.ensure_conda_packages`` call, the environment got modified and instead of having symlinks to python3.6, there were instead to python3.7, hence the "ModuleNotFoundError: No module named 'conda'" error.

<details>
<summary>conda-meta/history  contents before the running any test</summary>

```
+defaults::python-3.6.5-hc3d631a_2
+defaults::ca-certificates-2018.03.07-0
+defaults::conda-env-2.6.0-h36134e3_1
+defaults::libgcc-ng-7.2.0-hdf63c60_3
+defaults::libstdcxx-ng-7.2.0-hdf63c60_3
+defaults::libffi-3.2.1-hd88cf55_4
+defaults::ncurses-6.1-hf484d3e_0
+defaults::openssl-1.0.2o-h20670df_0
+defaults::tk-8.6.7-hc745277_3
+defaults::xz-5.2.4-h14c3975_4
+defaults::yaml-0.1.7-had09818_2
+defaults::zlib-1.2.11-ha838bed_2
+defaults::libedit-3.1.20170329-h6b74fdf_2
+defaults::readline-7.0-ha6073c6_4
+defaults::sqlite-3.23.1-he433501_0
+defaults::asn1crypto-0.24.0-py36_0
+defaults::certifi-2018.4.16-py36_0
+defaults::chardet-3.0.4-py36h0f667ec_1
+defaults::idna-2.6-py36h82fb2a8_1
+defaults::pycosat-0.6.3-py36h0a5515d_0
+defaults::pycparser-2.18-py36hf9f622e_1
+defaults::pysocks-1.6.8-py36_0
+defaults::ruamel_yaml-0.15.37-py36h14c3975_2
+defaults::six-1.11.0-py36h372c433_1
+defaults::cffi-1.11.5-py36h9745a5d_0
+defaults::setuptools-39.2.0-py36_0
+defaults::cryptography-2.2.2-py36h14c3975_0
+defaults::wheel-0.31.1-py36_0
+defaults::pip-10.0.1-py36_0
+defaults::pyopenssl-18.0.0-py36_0
+defaults::urllib3-1.22-py36hbe7ace6_0
+defaults::requests-2.18.4-py36he2e5f8d_1
+defaults::conda-4.5.4-py36_0
# update specs: ['conda', 'python=3']
```
</details>

<details>
<summary>conda-meta/history  contents after the running first test (conda.ensure_conda_packages(prefix, ['numpy'])) </summary>

```
-defaults::ca-certificates-2018.03.07-0
-defaults::certifi-2018.4.16-py36_0
-defaults::libffi-3.2.1-hd88cf55_4
-defaults::libgcc-ng-7.2.0-hdf63c60_3
-defaults::ncurses-6.1-hf484d3e_0
-defaults::openssl-1.0.2o-h20670df_0
-defaults::pip-10.0.1-py36_0
-defaults::python-3.6.5-hc3d631a_2
-defaults::readline-7.0-ha6073c6_4
-defaults::setuptools-39.2.0-py36_0
-defaults::sqlite-3.23.1-he433501_0
-defaults::tk-8.6.7-hc745277_3
-defaults::wheel-0.31.1-py36_0
-defaults::xz-5.2.4-h14c3975_4
-defaults::zlib-1.2.11-ha838bed_2
+conda-forge::bzip2-1.0.8-h516909a_0
+conda-forge::ca-certificates-2019.6.16-hecc5488_0
+conda-forge::certifi-2019.6.16-py37_1
+conda-forge::libblas-3.8.0-12_openblas
+conda-forge::libcblas-3.8.0-12_openblas
+conda-forge::libffi-3.2.1-hfc679d8_5
+conda-forge::liblapack-3.8.0-12_openblas
+conda-forge::libopenblas-0.3.7-h6e990d7_1
+conda-forge::ncurses-6.1-hfc679d8_2
+conda-forge::numpy-1.17.0-py37h95a1406_0
+conda-forge::openssl-1.0.2r-h14c3975_0
+conda-forge::pip-19.2.3-py37_0
+conda-forge::python-3.7.1-h5001a0f_0
+conda-forge::readline-7.0-hf8c457e_1001
+conda-forge::setuptools-41.2.0-py37_0
+conda-forge::sqlite-3.28.0-h8b20d00_0
+conda-forge::tk-8.6.9-hed695b0_1002
+conda-forge::wheel-0.33.6-py37_0
+conda-forge::xz-5.2.4-h14c3975_1001
+conda-forge::zlib-1.2.11-h516909a_1005
+defaults::_libgcc_mutex-0.1-main
+defaults::libgcc-ng-9.1.0-hdf63c60_0
+defaults::libgfortran-ng-7.3.0-hdf63c60_0
# update specs: ['numpy']
```
</details>

Because in TLJH  we're using [conda 4.5.8](https://github.com/jupyterhub/the-littlest-jupyterhub/blob/master/tljh/installer.py#L247), I *think* whatever is going on with the version in tests is not the case in TLJH (the test passes if we use the same conda 4.5.8)