### PR TITLE
Disable ProtectHome=tmpfs

### DIFF
--- a/tljh/systemd-units/jupyterhub.service
+++ b/tljh/systemd-units/jupyterhub.service
@@ -8,8 +8,6 @@ After=traefik.service
 [Service]
 User=root
 Restart=always
-# jupyterhub process should have no access to home directories
-ProtectHome=tmpfs
 WorkingDirectory={install_prefix}/state
 # Protect bits that are normally shared across the system
 PrivateTmp=yes

--- a/tljh/systemd-units/traefik.service
+++ b/tljh/systemd-units/traefik.service
@@ -7,7 +7,8 @@ After=network.target
 [Service]
 User=root
 Restart=always
-ProtectHome=tmpfs
+# traefik process should have no access to home directories
+ProtectHome=yes
 ProtectSystem=strict
 PrivateTmp=yes
 PrivateDevices=yes


### PR DESCRIPTION
This disables ProtectHome for jupyterhub process and enables it for the traefik process (ref: https://github.com/jupyterhub/the-littlest-jupyterhub/issues/431).

Should fix https://github.com/jupyterhub/the-littlest-jupyterhub/issues/431, https://github.com/jupyterhub/the-littlest-jupyterhub/issues/408 and https://github.com/jupyterhub/the-littlest-jupyterhub/issues/237.