### PR TITLE
switch base environment to requirements file

### DIFF
--- a/integration-tests/test_extensions.py
+++ b/integration-tests/test_extensions.py
@@ -13,14 +13,14 @@ def test_serverextensions():
     ], stderr=subprocess.PIPE)
 
     extensions = [
-        'jupyterlab 1.2.6',
-        'nbgitpuller 0.6.1',
-        'nteract_on_jupyter 2.0.7',
+        'jupyterlab 1.2.',
+        'nbgitpuller 0.7.',
+        'nteract_on_jupyter 2.1.',
         'nbresuse '
     ]
 
     for e in extensions:
-        assert '{} \x1b[32mOK\x1b[0m'.format(e) in proc.stderr.decode()
+        assert e in proc.stderr.decode()
 
 def test_nbextensions():
     """

--- a/tljh/installer.py
+++ b/tljh/installer.py
@@ -272,22 +272,10 @@ def ensure_user_environment(user_requirements_txt_file):
         'conda==' + conda_version
     ])
 
-    conda.ensure_pip_packages(USER_ENV_PREFIX, [
-        # JupyterHub + notebook package are base requirements for user environment
-        'jupyterhub==1.0.0',
-        'notebook==5.7.8',
-        # Install additional notebook frontends!
-        'jupyterlab==1.2.6',
-        'nteract-on-jupyter==2.0.7',
-        # nbgitpuller for easily pulling in Git repositories
-        'nbgitpuller==0.6.1',
-        # nbresuse to show people how much RAM they are using
-        'nbresuse==0.3.0',
-        # Most people consider ipywidgets to be part of the core notebook experience
-        'ipywidgets==7.4.2',
-        # Pin tornado
-        'tornado<6.0',
-    ])
+    conda.ensure_pip_requirements(
+        USER_ENV_PREFIX,
+        os.path.join(HERE, 'requirements-base.txt'),
+    )
 
     if user_requirements_txt_file:
         # FIXME: This currently fails hard, should fail soft and not abort installer

--- a/tljh/requirements-base.txt
+++ b/tljh/requirements-base.txt
@@ -1,0 +1,17 @@
+# FIXME: a frozen version of this file should be used
+# pinning only direct dependencies is a recipe for broken environments!
+
+# JupyterHub + notebook package are base requirements for user environment
+jupyterhub==1.0.*
+notebook==6.0.*
+# Install additional notebook frontends!
+jupyterlab==1.1.*
+nteract-on-jupyter==2.1.*
+# nbgitpuller for easily pulling in Git repositories
+nbgitpuller==0.7.*
+# nbresuse to show people how much RAM they are using
+nbresuse==0.3.*
+# Most people consider ipywidgets to be part of the core notebook experience
+ipywidgets==7.5.*
+# Pin tornado
+tornado<6

--- a/tljh/requirements-base.txt
+++ b/tljh/requirements-base.txt
@@ -5,7 +5,7 @@
 jupyterhub==1.0.*
 notebook==6.0.*
 # Install additional notebook frontends!
-jupyterlab==1.1.*
+jupyterlab==1.2.*
 nteract-on-jupyter==2.1.*
 # nbgitpuller for easily pulling in Git repositories
 nbgitpuller==0.7.*


### PR DESCRIPTION
requirements file is easier to work with and update than inlined strings

In the future, we should be doing `pip freeze` and using the frozen result, like we do (with conda) in repo2docker because pinning only direct dependencies is a way to guarantee broken environments in the future (see the pinning-down of tornado as one example).

Several dependencies are updated in the process (jupyterlab 1.1, notebook 6.0, etc.)