### PR TITLE
Use /health for check_hub_ready 

### DIFF
--- a/tljh/config.py
+++ b/tljh/config.py
@@ -240,7 +240,7 @@ def remove_config_value(config_path, key_path, value):
 
 def check_hub_ready():
     try:
-        r = requests.get('http://127.0.0.1:80', verify=False)
+        r = requests.get('http://127.0.0.1:80/health', verify=False)
         return r.status_code == 200
     except:
         return False


### PR DESCRIPTION
I am currently using a JWT authenticator with JupyterHub to authenticate with GCP's IAP. I noticed that any `sudo tljh-config reload` calls print out `active` and then hang indefinitely. When I escaped I would see the following error:
```
Traceback (most recent call last):
  File "/usr/bin/tljh-config", line 11, in <module>
    load_entry_point('the-littlest-jupyterhub==0.1', 'console_scripts', 'tljh-config')()
  File "/opt/tljh/hub/lib/python3.6/site-packages/tljh/config.py", line 398, in main
    reload_component(args.component)
  File "/opt/tljh/hub/lib/python3.6/site-packages/tljh/config.py", line 263, in reload_component
    time.sleep(1)
KeyboardInterrupt
```

Line 263 is calling the `check_hub_ready` function...

When looking at the logs I with `sudo journalctl -u jupyterhub -f` I would see redirects to login which ultimately return `401`.
```
Dec 23 17:31:26 <machine> python3[18600]: [I 2019-12-23 17:31:26.490 JupyterHub log:174] 302 GET / -> /hub/ (@127.0.0.1) 0.73ms
Dec 23 17:31:26 <machine> python3[18600]: [I 2019-12-23 17:31:26.494 JupyterHub log:174] 302 GET /hub/ -> /hub/login (@127.0.0.1) 0.54ms
Dec 23 17:31:26 <machine> python3[18600]: [W 2019-12-23 17:31:26.499 JupyterHub log:174] 401 GET /hub/login (@127.0.0.1) 1.45ms
```

I replicated this on the server by running the following and got the same result.
```
requests.get('http://127.0.0.1:80', verify=False)
```
However when I hit the `/health` endpoint it returned `200`:
```
requests.get('http://127.0.0.1:80/health', verify=False)
```
With the following in the logs...
```
Dec 23 19:01:25 <machine> python3[19529]: [I 2019-12-23 19:01:25.048 JupyterHub log:174] 302 GET /health -> /hub/health (@127.0.0.1) 0.74ms
Dec 23 19:01:25 <machine> python3[19529]: [I 2019-12-23 19:01:25.054 JupyterHub log:174] 200 GET /hub/health (@127.0.0.1) 1.71ms
```

This also seems like it would be the more appropriate endpoint to hit for this check.