### PR TITLE
Upgrade authenticators

### DIFF
--- a/tljh/installer.py
+++ b/tljh/installer.py
@@ -205,11 +205,11 @@ def ensure_jupyterhub_package(prefix):
         'jupyterhub==1.0.0',
         'jupyterhub-dummyauthenticator==0.3.1',
         'jupyterhub-systemdspawner==0.13',
-        'jupyterhub-firstuseauthenticator==0.12',
+        'jupyterhub-firstuseauthenticator==0.13.0',
         'jupyterhub-nativeauthenticator==0.0.4',
         'jupyterhub-ldapauthenticator==1.2.2',
         'jupyterhub-tmpauthenticator==0.6',
-        'oauthenticator==0.8.2',
+        'oauthenticator==0.10.0',
     ])
     traefik.ensure_traefik_binary(prefix)
 


### PR DESCRIPTION
* Upgrade **firsuseauthenticator** to v0.13.0 to include [a fix](https://github.com/jupyterhub/firstuseauthenticator/pull/23) that solves the *500 : Internal Server Error* when accessing  `/hub/auth/change-password`.
  Closes https://github.com/jupyterhub/the-littlest-jupyterhub/issues/306
* Upgrade **oauthenticator** to v0.10.0 to offer support for aws cognito.
Closes https://github.com/jupyterhub/the-littlest-jupyterhub/issues/471

 <!-- Read more about our code-review guidelines at https://the-littlest-jupyterhub.readthedocs.io/en/latest/contributing/code-review.html -->