### PR TITLE
Fix failing integration tests

### DIFF
--- a/.circleci/integration-test.py
+++ b/.circleci/integration-test.py
@@ -32,7 +32,7 @@ def run_systemd_image(image_name, container_name):
         # This is the minimum VM size we support. JupyterLab extensions seem
         # to need at least this much RAM to build. Boo?
         # If we change this, need to change all other references to this number.
-        '--memory', '768M',
+        '--memory', '1G',
         image_name
     ])
 

--- a/docs/howto/admin/resource-estimation.rst
+++ b/docs/howto/admin/resource-estimation.rst
@@ -12,7 +12,7 @@ Memory
 ======
 
 Memory is usually the biggest determinant of server size in most JupyterHub
-installations. At minimum, your server must have at least **768MB** of RAM
+installations. At minimum, your server must have at least **1GB** of RAM
 for TLJH to install.
 
 .. math::

--- a/docs/install/amazon.rst
+++ b/docs/install/amazon.rst
@@ -79,7 +79,7 @@ Let's create the server on which we can run JupyterHub.
    `Next: Configure Instance Details` in the lower right corner.  
    
    Check out our guide on How To :ref:`howto/admin/resource-estimation` to help pick
-   how much Memory / CPU your server needs. You need to have at least **768MB** of
+   how much Memory / CPU your server needs. You need to have at least **1GB** of
    RAM.
    
    You may wish to consult the listing `here <https://www.ec2instances.info/>`_ 

--- a/docs/install/custom-server.rst
+++ b/docs/install/custom-server.rst
@@ -32,7 +32,7 @@ Pre-requisites
 
 #. Some familiarity with the command line.
 #. A server running Ubuntu 18.04 where you have root access.
-#. At least **768MB** of RAM on your server.
+#. At least **1GB** of RAM on your server.
 #. Ability to ``ssh`` into the server & run commands from the prompt.
 #. A **IP address** where the server can be reached from the browsers of your target audience.
 

--- a/docs/install/google.rst
+++ b/docs/install/google.rst
@@ -69,7 +69,7 @@ Let's create the server on which we can run JupyterHub.
 #. For **Zone**, pick any of the options. Leaving the default as is is fine.
 
 #. Under **Machine** type, select the amount of CPU / RAM / GPU you want for your
-   server. You need at least **768MB** of RAM.
+   server. You need at least **1GB** of RAM.
 
    You can select a preset combination in the default **basic view**.
 

--- a/docs/install/jetstream.rst
+++ b/docs/install/jetstream.rst
@@ -53,7 +53,7 @@ Let's create the server on which we can run JupyterHub.
 
    #. Give your server a descriptive **Instance Name**.
    #. Select an appropriate **Instance Size**. We suggest m1.medium or larger.
-      Make sure your instance has at least **768MB** of RAM.
+      Make sure your instance has at least **1GB** of RAM.
 
       Check out our guide on How To :ref:`howto/admin/resource-estimation` to help pick
       how much Memory, CPU & disk space your server needs.

--- a/integration-tests/plugins/simplest/tljh_simplest.py
+++ b/integration-tests/plugins/simplest/tljh_simplest.py
@@ -51,4 +51,4 @@ def tljh_post_install():
 @hookimpl
 def tljh_new_user_create(username):
     with open('test_new_user_create', 'w') as f:
-        f.write("a new userfile")
+        f.write(username)

--- a/integration-tests/test_simplest_plugin.py
+++ b/integration-tests/test_simplest_plugin.py
@@ -5,7 +5,9 @@ from ruamel.yaml import YAML
 import requests
 import os
 import subprocess
+
 from tljh.config import CONFIG_FILE, USER_ENV_PREFIX, HUB_ENV_PREFIX
+from tljh import user
 
 yaml = YAML(typ='rt')
 
@@ -74,11 +76,15 @@ def test_post_install_hook():
     assert content == "123456789"
 
 
-def test_tljh_new_user_create():
+def test_new_user_create():
     """
     Test that plugin receives username as arg
     """
-    with open("test_new_user_create") as f:
+    username="user1"
+    # Call ensure_user to make sure the user plugin gets called
+    user.ensure_user(username)
+
+    with open(f"test_new_user_create") as f:
         content = f.read()
 
-    assert content == "a new userfile"
+    assert content == username


### PR DESCRIPTION
Apparently the 768MB memory limit is not enough anymore and it caused the integration tests failure.
Increasing it to 1GB seems to solve the issues (at least for now).

ref: https://github.com/jupyterhub/the-littlest-jupyterhub/issues/257 and https://github.com/jupyterhub/the-littlest-jupyterhub/pull/335

P.S: Remaining things to do for the tests to pass: find out why the test in https://github.com/jupyterhub/the-littlest-jupyterhub/pull/453 fails.

 <!-- Read more about our code-review guidelines at https://the-littlest-jupyterhub.readthedocs.io/en/latest/contributing/code-review.html -->