### PR TITLE
Fix broken link to resource estimation page

### DIFF
--- a/docs/topic/requirements.rst
+++ b/docs/topic/requirements.rst
@@ -26,4 +26,4 @@ about how to get HTTP traffic from the world into your server.
 CPU / Memory / Disk Space
 =========================
 
-See how to ref:`howto/resource-estimation`
+See how to ref:`howto/admin/resource-estimation`


### PR DESCRIPTION
The link was missing the `admin` folder under `howto`.

 - [ ] Add / update documentation
 - [ ] Add tests

 <!-- Read more about our code-review guidelines at https://the-littlest-jupyterhub.readthedocs.io/en/latest/contributing/code-review.html -->