### PR TITLE
[MRG] Link contributing guide

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,0 +1,8 @@
+Contributing to The Littlest JupyterHub development
+---------------------------------------------------
+
+This is an open source project that is developed and maintained by volunteers.
+Your contribution is integral to the future of the project. Thank you!
+
+See the `contributing guide <https://the-littlest-jupyterhub.readthedocs.io/en/latest/contributing/index.html>`_
+for information on the different ways of contributing to The Littlest JupyterHub.

--- a/README.rst
+++ b/README.rst
@@ -10,6 +10,8 @@ The Littlest JupyterHub
    :target: https://the-littlest-jupyterhub.readthedocs.io
 .. image:: https://badges.gitter.im/jupyterhub/jupyterhub.svg
    :target: https://gitter.im/jupyterhub/jupyterhub
+.. image:: https://img.shields.io/badge/I_want_to_contribute!-grey?logo=jupyter
+   :target: https://the-littlest-jupyterhub.readthedocs.io/en/latest/contributing/index.html
 
 **The Littlest JupyterHub** (TLJH) distribution helps you provide Jupyter Notebooks
 to 1-50 users on a single server.
@@ -25,7 +27,7 @@ for more information on using The Littlest JupyterHub.
 For support questions please search or post to `our forum <https://discourse.jupyter.org/c/jupyterhub/>`_.
 
 See the `contributing guide <https://the-littlest-jupyterhub.readthedocs.io/en/latest/contributing/index.html>`_
-for information on the different ways of contributing to the littlest JupyterHub.
+for information on the different ways of contributing to The Littlest JupyterHub.
 
 See `this blog post <http://words.yuvi.in/post/the-littlest-jupyterhub/>`_ for
 more information.

--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ for more information on using The Littlest JupyterHub.
 
 For support questions please search or post to `our forum <https://discourse.jupyter.org/c/jupyterhub/>`_.
 
-See the `contributing guide <https://the-littlest-jupyterhub.readthedocs.io/en/latest/contributing/index.html>`_`
+See the `contributing guide <https://the-littlest-jupyterhub.readthedocs.io/en/latest/contributing/index.html>`_
 for information on the different ways of contributing to the littlest JupyterHub.
 
 See `this blog post <http://words.yuvi.in/post/the-littlest-jupyterhub/>`_ for

--- a/README.rst
+++ b/README.rst
@@ -14,13 +14,22 @@ The Littlest JupyterHub
 **The Littlest JupyterHub** (TLJH) distribution helps you provide Jupyter Notebooks
 to 1-50 users on a single server.
 
-Administrators who do not consider themselves 'system administrators' but would
-like to provide hosted Jupyter Notebooks for their students / users are the
-primary audience. All users are provided with the same environment, and administrators
+The primary audience are people who do not consider themselves 'system administrators'
+but would like to provide hosted Jupyter Notebooks for their students or users.
+All users are provided with the same environment, and administrators
 can easily install libraries into this environment without any specialized knowledge.
+
+See the `latest documentation <https://the-littlest-jupyterhub.readthedocs.io>`_
+for more information on using The Littlest JupyterHub.
+
+For support questions please search or post to `our forum <https://discourse.jupyter.org/c/jupyterhub/>`_.
+
+See the `contributing guide <https://the-littlest-jupyterhub.readthedocs.io/en/latest/contributing/index.html>`_`
+for information on the different ways of contributing to the littlest JupyterHub.
 
 See `this blog post <http://words.yuvi.in/post/the-littlest-jupyterhub/>`_ for
 more information.
+
 
 Development Status
 ==================
@@ -34,7 +43,7 @@ Installation
 
 The Littlest JupyterHub (TLJH) can run on any server that is running at least
 **Ubuntu 18.04**. Earlier versions of Ubuntu are not supported.
-We have a bunch of tutorials to get you started.
+We have several tutorials to get you started.
 
 - Tutorials to create a new server from scratch on a cloud provider & run TLJH
   on it. These are **recommended** if you do not have much experience setting up

--- a/docs/contributing/index.rst
+++ b/docs/contributing/index.rst
@@ -9,7 +9,7 @@ Your contribution is integral to the future of the project. Thank you!
 
 This section contains documentation for people who want to contribute.
 
-You can find the `source code on GitHub <>`_
+You can find the `source code on GitHub <https://github.com/jupyterhub/the-littlest-jupyterhub/tree/master/tljh>`_
 
 .. toctree::
    :titlesonly:

--- a/docs/contributing/index.rst
+++ b/docs/contributing/index.rst
@@ -2,16 +2,21 @@
 Contributing
 ============
 
-We want you to contribute to TLJH in the ways that are most useful
-and exciting to you. This section contains documentation helpful
-to people contributing in various ways.
+✨ Thank you for thinking about contributing to the littlest JupyterHub! ✨
+
+This is an open source project that is developed and maintained by volunteers.
+Your contribution is integral to the future of the project. Thank you!
+
+This section contains documentation for people who want to contribute.
+
+You can find the `source code on GitHub <>`_
 
 .. toctree::
    :titlesonly:
 
    docs
-   code-review
    dev-setup
    tests
    plugins
+   code-review
    packages


### PR DESCRIPTION
This PR links the contributing guide more prominently.

i also changed the wording at the top of the contributing section a bit. This is taken from what we have in https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html. For BinderHub we have a slightly different setup https://github.com/jupyterhub/binderhub#contributing

I think making it as easy as possible to find the contributing guide helps show people new to the project that there are several ways of contributing and that they aren't super difficult or require specialised knowledge. It is also useful for repeat contributors because they want a reminder of how things work (build the docs, run the tests, etc).

What do you think?