### PR TITLE
[MRG] Fix integration test for new pip

### DIFF
--- a/integration-tests/test_install.py
+++ b/integration-tests/test_install.py
@@ -207,6 +207,7 @@ def test_pip_upgrade(group, allowed):
                 "-m",
                 "pip",
                 "install",
+                "--no-user",
                 "--ignore-installed",
                 "--no-deps",
                 "testpath==0.3.0",
@@ -218,6 +219,7 @@ def test_pip_upgrade(group, allowed):
             [python, "-m", "pip", "install", "--upgrade", "testpath"],
             preexec_fn=partial(setgroup, group),
         )
+
 
 def test_symlinks():
     """

--- a/integration-tests/test_install.py
+++ b/integration-tests/test_install.py
@@ -123,6 +123,7 @@ def test_installer_log_readable():
     assert file_stat.st_uid == 0
     assert file_stat.st_mode == 0o100500
 
+
 @pytest.mark.parametrize("group", [ADMIN_GROUP, USER_GROUP])
 def test_user_env_readable(group):
     # every file in user env should be readable by everyone
@@ -163,8 +164,15 @@ def test_pip_install(group, allowed):
     python = os.path.join(USER_PREFIX, "bin", "python")
 
     with context:
+        # we explicitly add `--no-user` here even though a real user wouldn't
+        # With this test we want to check that a user can't install to the
+        # global site-packages directory. In new versions of pip the default
+        # behaviour is to install to a user location when a global install
+        # isn't possible. By using --no-user we disable this behaviour and
+        # get a failure if the user can't install to the global site. Which is
+        # what we wanted to test for here.
         subprocess.check_call(
-            [python, "-m", "pip", "install", "--ignore-installed", "--no-deps", "flit"],
+            [python, "-m", "pip", "install", "--no-user", "--ignore-installed", "--no-deps", "flit"],
             preexec_fn=partial(setgroup, group),
         )
     if allowed:


### PR DESCRIPTION
This is an attempt to fix the integration test. Closes #490.

The TL;DR is that the [newest version of pip](https://pip.pypa.io/en/stable/news/#features) will switch to the behaviour of `pip install --user ...` when you run `pip install ...` without being able to write to the global package directory. This means our integration test started to fail because the install we were doing now succeeded. However we were testing if a user could install things to the global directory or not. This means the test failing was a false positive (the install succeeded but not because the user could write to the global dir).

This PR makes it so that the `pip` command used in the test won't enable `--user` if it can't write to the global directory. Instead it will fail (as it used to).

An alternative would be to check if the pip command fails and if it succeeds check the location the package got installed to.