### PR TITLE
Set tls 1.2 to be the min version

### DIFF
--- a/tests/test_traefik.py
+++ b/tests/test_traefik.py
@@ -69,7 +69,7 @@ def test_letsencrypt_config(tljh_dir):
 
     assert cfg["entryPoints"] == {
         "http": {"address": ":80", "redirect": {"entryPoint": "https"}},
-        "https": {"address": ":443", "tls": {}},
+        "https": {"address": ":443", "tls": {"minVersion": "VersionTLS12"}},
         "auth_api": {
             "address": "127.0.0.1:8099",
             "auth": {
@@ -110,6 +110,7 @@ def test_manual_ssl_config(tljh_dir):
         "https": {
             "address": ":443",
             "tls": {
+                "minVersion": "VersionTLS12",
                 "certificates": [
                     {"certFile": "/path/to/ssl.cert", "keyFile": "/path/to/ssl.key"}
                 ]

--- a/tljh/traefik.toml.tpl
+++ b/tljh/traefik.toml.tpl
@@ -34,6 +34,7 @@ idleTimeout = "10m0s"
   [entryPoints.https]
   address = ":{{https['port']}}"
   [entryPoints.https.tls]
+  minVersion = "VersionTLS12"
   {% if https['tls']['cert'] %}
     [[entryPoints.https.tls.certificates]]
       certFile = "{{https['tls']['cert']}}"


### PR DESCRIPTION
This sets TLS 1.2 to be the minimum tls version for the https entry point.

traefik 1.7 docs ref: https://docs.traefik.io/v1.7/configuration/entrypoints/#specify-minimum-tls-version

closes https://github.com/jupyterhub/the-littlest-jupyterhub/issues/488

 <!-- Read more about our code-review guidelines at https://the-littlest-jupyterhub.readthedocs.io/en/latest/contributing/code-review.html -->