### PR TITLE
Upgrade jupyterlab to 1.2.6

### DIFF
--- a/integration-tests/test_extensions.py
+++ b/integration-tests/test_extensions.py
@@ -13,7 +13,7 @@ def test_serverextensions():
     ], stderr=subprocess.PIPE)
 
     extensions = [
-        'jupyterlab 0.35.4',
+        'jupyterlab 1.2.6',
         'nbgitpuller 0.6.1',
         'nteract_on_jupyter 2.0.7',
         'nbresuse '
@@ -51,3 +51,4 @@ def test_labextensions():
     """
     # Currently we only install jupyterhub
     assert os.path.exists('/opt/tljh/user/bin/jupyter-labhub')
+    

--- a/tljh/installer.py
+++ b/tljh/installer.py
@@ -170,14 +170,13 @@ def ensure_jupyterlab_extensions():
     Install the JupyterLab extensions we want.
     """
     extensions = [
-        '@jupyterlab/hub-extension',
-        '@jupyter-widgets/jupyterlab-manager'
+        '@jupyter-widgets/jupyterlab-manager@1.1' # for jupyterlab 1.2.x
     ]
     utils.run_subprocess([
         os.path.join(USER_ENV_PREFIX, 'bin/jupyter'),
         'labextension',
         'install'
-    ] + extensions)
+    ] + extensions + ['--minimize=False']) # webpack minimization might cause flaky test build
 
 
 def ensure_jupyterhub_package(prefix):
@@ -263,7 +262,7 @@ def ensure_user_environment(user_requirements_txt_file):
         'jupyterhub==1.0.0',
         'notebook==5.7.8',
         # Install additional notebook frontends!
-        'jupyterlab==0.35.4',
+        'jupyterlab==1.2.6',
         'nteract-on-jupyter==2.0.7',
         # nbgitpuller for easily pulling in Git repositories
         'nbgitpuller==0.6.1',

--- a/tljh/installer.py
+++ b/tljh/installer.py
@@ -172,11 +172,26 @@ def ensure_jupyterlab_extensions():
     extensions = [
         '@jupyter-widgets/jupyterlab-manager@1.1' # for jupyterlab 1.2.x
     ]
+    install_options = [
+        '--no-build'   # do not build extension at install time. Will build later
+    ]
     utils.run_subprocess([
         os.path.join(USER_ENV_PREFIX, 'bin/jupyter'),
         'labextension',
         'install'
-    ] + extensions + ['--minimize=False']) # webpack minimization might cause flaky test build
+    ] + extensions + install_options)
+    
+    # Build all the lab extensions in one go using jupyter lab build command
+    build_options = [
+        '--minimize=False',
+        '--dev-build=False'
+    ]
+
+    utils.run_subprocess([
+        os.path.join(USER_ENV_PREFIX, 'bin/jupyter'),
+        'lab',
+        'build'
+    ] + build_options)
 
 
 def ensure_jupyterhub_package(prefix):


### PR DESCRIPTION
This PR upgrades Jupyterlab to the latest version of 1.2.6 as of Feb 1st 2020. Build and integration tests passes locally. 

- `jupyterlab-hubextension` removed because this has been integrated to Jupyterlab 1.0.0+ 
- Added `--minimize=False` option to Jupyterlab installation to avoid flaky build on low resource CI pipelines

 - [ ] Add / update documentation
 - [X] Add tests

 <!-- Read more about our code-review guidelines at https://the-littlest-jupyterhub.readthedocs.io/en/latest/contributing/code-review.html -->