### PR TITLE
Fix missing reference to requirements-base.txt

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include tljh/systemd-units/*
 include tljh/*.tpl
+include tljh/requirements-base.txt


### PR DESCRIPTION
Include `requirements-base.txt` in MANIFEST so it gets installed.
Fixes https://github.com/jupyterhub/the-littlest-jupyterhub/issues/502

 <!-- Read more about our code-review guidelines at https://the-littlest-jupyterhub.readthedocs.io/en/latest/contributing/code-review.html -->