### PR TITLE
Fix installer

### DIFF
--- a/tljh/installer.py
+++ b/tljh/installer.py
@@ -254,18 +254,18 @@ def ensure_user_environment(user_requirements_txt_file):
 
     miniconda_old_version = '4.5.4'
     miniconda_new_version = '4.7.10'
-    conda_version = '4.5.8'
+    miniconda_installer_md5 = "1c945f2b3335c7b2b15130b1b2dc5cf4"
 
-    # If no prior miniconda installation is found, we can install a newer version
-    if not conda.check_miniconda_version(
-        USER_ENV_PREFIX, miniconda_old_version
-    ) and not conda.check_miniconda_version(USER_ENV_PREFIX, miniconda_new_version):
-        miniconda_installer_md5 = "1c945f2b3335c7b2b15130b1b2dc5cf4"
+    if conda.check_miniconda_version(USER_ENV_PREFIX, miniconda_new_version):
         conda_version = '4.8.1'
-
+    elif conda.check_miniconda_version(USER_ENV_PREFIX, miniconda_old_version):
+        conda_version = '4.5.8'
+    # If no prior miniconda installation is found, we can install a newer version
+    else:
         logger.info('Downloading & setting up user environment...')
         with conda.download_miniconda_installer(miniconda_new_version, miniconda_installer_md5) as installer_path:
             conda.install_miniconda(installer_path, USER_ENV_PREFIX)
+        conda_version = '4.8.1'
 
     conda.ensure_conda_packages(USER_ENV_PREFIX, [
         # Conda's latest version is on conda much more so than on PyPI.


### PR DESCRIPTION
There is a bug in the upgrade logic of the installer. On a fresh TLJH install, conda 4.8.1 is installed.
If the installer is run again, instead of using the existing conda 4.8.1, conda 4.5.8 is installed and used, producing a *CondaUpgradeError*. 

This should fix this issue.
Closes https://github.com/jupyterhub/the-littlest-jupyterhub/issues/517 
Closes https://github.com/jupyterhub/the-littlest-jupyterhub/issues/332

 <!-- Read more about our code-review guidelines at https://the-littlest-jupyterhub.readthedocs.io/en/latest/contributing/code-review.html -->