### PR TITLE
[WIP] Add --hub-requirements-txt-url to the installer

### DIFF
--- a/docs/topic/customizing-installer.rst
+++ b/docs/topic/customizing-installer.rst
@@ -53,7 +53,7 @@ during install you would:
      | sudo python3 - \
        --admin admin-user1:password-user1 --admin admin-user2
 
-Installing python packages in the user environment
+Installing Python packages in the user environment
 ==================================================
 
 ``--user-requirements-txt-url <url-to-requirements.txt>`` installs packages specified
@@ -78,6 +78,21 @@ will fail.
    When pointing to a file on GitHub, make sure to use the 'Raw' version. It should point to
    ``raw.githubusercontent.com``, not ``github.com``.
 
+Installing extra Python packages in the hub environment
+=======================================================
+
+It is also possible to install extra packages in the hub environment.
+
+This makes it possible to install additional spawners and authenticators that are not part of TLJH by default.
+
+For example, to install ``dockerspawner`` and ``jhub_cas_authenticator`` in the hub environment:
+
+.. code-block:: bash
+
+    curl https://raw.githubusercontent.com/jupyterhub/the-littlest-jupyterhub/master/bootstrap/bootstrap.py \
+     | sudo python3 - \
+       --hub-requirements-txt-url https://gist.githubusercontent.com/jtpio/1473a908e53a39cf695ff9fccbfcf665/raw/e02e9f1280a9826fc8950e7df3b606aca19edf1b/requirements.txt
+
 Installing TLJH plugins
 =======================
 
@@ -87,7 +102,7 @@ the `PANGEO Stack <https://github.com/yuvipanda/tljh-pangeo>`_ for earth science
 research, a stack for a particular class, etc.
 
 ``--plugin <plugin-to-install>`` installs and activates a plugin. You can pass it
-however many times you want. Since plugins are distributed as python packages,
+however many times you want. Since plugins are distributed as Python packages,
 ``<plugin-to-install>`` can be anything that can be passed to ``pip install`` -
 ``plugin-name-on-pypi==<version>`` and ``git+https://github.com/user/repo@tag``
 are the most popular ones. Specifying a version or tag is highly recommended.

--- a/tljh/installer.py
+++ b/tljh/installer.py
@@ -180,7 +180,7 @@ def ensure_jupyterlab_extensions():
         'labextension',
         'install'
     ] + extensions + install_options)
-    
+
     # Build all the lab extensions in one go using jupyter lab build command
     build_options = [
         '--minimize=False',
@@ -194,7 +194,7 @@ def ensure_jupyterlab_extensions():
     ] + build_options)
 
 
-def ensure_jupyterhub_package(prefix):
+def ensure_jupyterhub_package(prefix, hub_requirements_txt_file):
     """
     Install JupyterHub into our conda environment if needed.
 
@@ -212,6 +212,7 @@ def ensure_jupyterhub_package(prefix):
         'libcurl4-openssl-dev',
         'build-essential'
     ])
+
     conda.ensure_pip_packages(prefix, [
         'pycurl==7.43.*'
     ])
@@ -226,6 +227,10 @@ def ensure_jupyterhub_package(prefix):
         'jupyterhub-tmpauthenticator==0.6',
         'oauthenticator==0.10.0',
     ])
+
+    if hub_requirements_txt_file:
+        conda.ensure_pip_requirements(prefix, hub_requirements_txt_file)
+
     traefik.ensure_traefik_binary(prefix)
 
 
@@ -472,6 +477,10 @@ def main():
         help='List of usernames set to be admin'
     )
     argparser.add_argument(
+        '--hub-requirements-txt-url',
+        help='URL to a requirements.txt file that should be installed in the hub environment'
+    )
+    argparser.add_argument(
         '--user-requirements-txt-url',
         help='URL to a requirements.txt file that should be installed in the user enviornment'
     )
@@ -492,7 +501,7 @@ def main():
 
     logger.info("Setting up JupyterHub...")
     ensure_node()
-    ensure_jupyterhub_package(HUB_ENV_PREFIX)
+    ensure_jupyterhub_package(HUB_ENV_PREFIX, args.hub_requirements_txt_url)
     ensure_jupyterlab_extensions()
     ensure_jupyterhub_service(HUB_ENV_PREFIX)
     ensure_jupyterhub_running()


### PR DESCRIPTION
Fixes #525.

Similar to the user requirements, this change lets specify extra hub requirements to the installer.

Although this could probably be achieved in a plugin by implementing the `tljh_extra_hub_pip_packages` hook, this flag makes it more convenient to install additional spawners and authenticators.

![image](https://user-images.githubusercontent.com/591645/76070039-31970200-5f94-11ea-8bec-f2c87ca24b2f.png)

 - [x] Add / update documentation
 - [ ] Add tests