### PR TITLE
Use PR username when no CircleCI project

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,11 @@ commands:
             - run:
                 name: Run basic tests
                 command: |
-                    BOOTSTRAP_PIP_SPEC=git+https://github.com/$CIRCLE_PROJECT_USERNAME/the-littlest-jupyterhub.git@$CIRCLE_SHA1
+                    if [ $CIRCLE_PR_USERNAME ]; then
+                        BOOTSTRAP_PIP_SPEC=git+https://github.com/$CIRCLE_PR_USERNAME/the-littlest-jupyterhub.git@$CIRCLE_SHA1
+                    else
+                        BOOTSTRAP_PIP_SPEC=git+https://github.com/$CIRCLE_PROJECT_USERNAME/the-littlest-jupyterhub.git@$CIRCLE_SHA1
+                    fi
 
                     .circleci/integration-test.py run-test basic-tests \
                     "$BOOTSTRAP_PIP_SPEC" test_hub.py test_install.py test_extensions.py \
@@ -56,7 +60,11 @@ commands:
             - run:
                 name: Run admin tests
                 command: |
-                    BOOTSTRAP_PIP_SPEC=git+https://github.com/$CIRCLE_PROJECT_USERNAME/the-littlest-jupyterhub.git@$CIRCLE_SHA1
+                    if [ $CIRCLE_PR_USERNAME ]; then
+                        BOOTSTRAP_PIP_SPEC=git+https://github.com/$CIRCLE_PR_USERNAME/the-littlest-jupyterhub.git@$CIRCLE_SHA1
+                    else
+                        BOOTSTRAP_PIP_SPEC=git+https://github.com/$CIRCLE_PROJECT_USERNAME/the-littlest-jupyterhub.git@$CIRCLE_SHA1
+                    fi
 
                     .circleci/integration-test.py run-test \
                     --installer-args "--admin admin:admin" \
@@ -72,7 +80,11 @@ commands:
             - run:
                 name: Run plugin tests
                 command: |
-                    BOOTSTRAP_PIP_SPEC=git+https://github.com/$CIRCLE_PROJECT_USERNAME/the-littlest-jupyterhub.git@$CIRCLE_SHA1
+                    if [ $CIRCLE_PR_USERNAME ]; then
+                        BOOTSTRAP_PIP_SPEC=git+https://github.com/$CIRCLE_PR_USERNAME/the-littlest-jupyterhub.git@$CIRCLE_SHA1
+                    else
+                        BOOTSTRAP_PIP_SPEC=git+https://github.com/$CIRCLE_PROJECT_USERNAME/the-littlest-jupyterhub.git@$CIRCLE_SHA1
+                    fi
 
                     .circleci/integration-test.py run-test \
                         --installer-args "--plugin /srv/src/integration-tests/plugins/simplest" \


### PR DESCRIPTION
1. When implementing https://github.com/jupyterhub/the-littlest-jupyterhub/pull/511, I didn't realize that when a TLJH fork doesn't have CircleCI setup there's no CIRCLE_PROJECT_USERNAME env var. Instead there is a  CIRCLE_PR_USERNAME that can be used.

Example:
* My TLJH fork has CircleCI setup, there are these env vars available:
![project](https://user-images.githubusercontent.com/7579677/76200675-bb480900-61fa-11ea-80d1-562da70281b2.png)
* @minrk and @jtpio recent PRs don't have these env vars and instead have:
![min](https://user-images.githubusercontent.com/7579677/76200787-e03c7c00-61fa-11ea-9fea-74368e60cf59.png)
![jtpio](https://user-images.githubusercontent.com/7579677/76200797-e29ed600-61fa-11ea-981b-e625604b33e7.png)

2. Another way to solve this issue is installing from git refs (available since [pip 10](https://pip.pypa.io/en/stable/news/#id280)). However this would imply some gymnastics parsing the CIRCLE_PULL_REQUEST var.
![circle_pr](https://user-images.githubusercontent.com/7579677/76202304-4a562080-61fd-11ea-854b-f179e66a9349.png)
like this:
```
index = CIRCLE_PULL_REQUEST.find("/pull/")
BOOTSTRAP_PIP_SPEC="git+" + CIRCLE_PULL_REQUEST[:index] + ".git@ref" + CIRCLE_PULL_REQUEST[index:] + "/head"
```

So that in the end to have BOOTSTRAP_PIP_SPEC be:
`git+https://github.com/jupyterhub/the-littlest-jupyterhub.git@ref/pull/527/head`

**What do folks think is the better way?**