### PR TITLE
Update the docs theme to pydata-sphinx-theme

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,7 +34,7 @@ intersphinx_cache_limit = 90 # days
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'
 
-html_theme = 'pandas_sphinx_theme'
+html_theme = 'pydata_sphinx_theme'
 
 html_logo = 'images/logo/logo.png'
 html_favicon = 'images/logo/favicon.ico'

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
 sphinx>=1.4, !=1.5.4
 sphinx_copybutton
-git+https://github.com/pandas-dev/pandas-sphinx-theme.git@master
+pydata-sphinx-theme


### PR DESCRIPTION
The `pydata-sphinx-theme` is now available on PyPI and conda-forge.

See also: https://github.com/jupyter/repo2docker/pull/864 and https://github.com/jupyterhub/the-littlest-jupyterhub/pull/537#pullrequestreview-379476596.

 - [x] Add / update documentation
