### PR TITLE
Fix code block formatting in the docs

### DIFF
--- a/docs/howto/content/add-data.rst
+++ b/docs/howto/content/add-data.rst
@@ -85,7 +85,9 @@ time. You can download it from your browser `at this link <https://swcarpentry.g
 
 #. Finally, unzip the file:
 
-   unzip python-novice-gapminder-data.zip
+   .. code-block:: bash
+
+      unzip python-novice-gapminder-data.zip
 
 #. Confirm that your data was unzipped. It could be in a folder called ``data/``.
 


### PR DESCRIPTION
Fix a minor formatting issue in the how-to guides.

### Before

![image](https://user-images.githubusercontent.com/591645/77463923-ad9f9f80-6e06-11ea-8e26-0c4b8afc65fd.png)

### After

![image](https://user-images.githubusercontent.com/591645/77463968-c314c980-6e06-11ea-9d07-6128b2f5724f.png)

 - [x] Add / update documentation
