### PR TITLE
Fix failing unit test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,14 @@ commands:
                 command: |
                     apt-get update --yes && apt-get install --yes python3 python3-venv git make
 
+    upgrade_pip:
+        description: Upgrade the pip version to 20.0.*
+        steps:
+            - run:
+                name: upgrade pip
+                command: |
+                    python3 -m pip install -U pip==20.0.*
+
     build_systemd_image:
         steps:
             - run:
@@ -116,6 +124,9 @@ jobs:
                     - v1-dependencies-py3.6-
 
             - setup_venv
+
+            - upgrade_pip
+
             - run:
                 name: install dependencies
                 command: |
@@ -211,6 +222,7 @@ jobs:
                 key: v1-dependencies-py3.6-sphinx
 
             - setup_venv
+
             - run:
                 name: install dependencies
                 command: |

--- a/bootstrap/bootstrap.py
+++ b/bootstrap/bootstrap.py
@@ -153,6 +153,15 @@ def main():
         'git+https://github.com/jupyterhub/the-littlest-jupyterhub.git'
     )
 
+    # Upgrade pip
+    run_subprocess([
+        os.path.join(hub_prefix, 'bin', 'pip'),
+        'install',
+        '--upgrade',
+        'pip==20.0.*'
+    ])
+    logger.info('Upgraded pip')
+
     run_subprocess([
         os.path.join(hub_prefix, 'bin', 'pip'),
         'install'

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,3 +3,4 @@ pytest-cov
 pytest-mock
 codecov
 pytoml
+grpcio==1.27.*

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,4 +3,3 @@ pytest-cov
 pytest-mock
 codecov
 pytoml
-grpcio==1.27.*


### PR DESCRIPTION
The unit test were failing because of the latest grpcio version 1.28.0, that switches to manylinux2010 (see [this announcement](https://groups.google.com/forum/#!msg/grpc-io/VdoTPMT5WwU/fMmXxFiBAwAJ) for details) (`grpcio` is a requirement of the `etcd3` python client used by traefik-proxy).

I tried a clean install of TLJH on DO and everything went ok, so referring to the info in the announcement I guess it has something to do with the Ubuntu Docker image and the libs there.

 <!-- Read more about our code-review guidelines at https://the-littlest-jupyterhub.readthedocs.io/en/latest/contributing/code-review.html -->