### PR TITLE
Remove unused plugins argument from run_plugin_actions

### DIFF
--- a/tljh/installer.py
+++ b/tljh/installer.py
@@ -396,7 +396,7 @@ def setup_plugins(plugins=None):
     return pm
 
 
-def run_plugin_actions(plugin_manager, plugins):
+def run_plugin_actions(plugin_manager):
     """
     Run installer hooks defined in plugins
     """
@@ -499,7 +499,7 @@ def main():
     ensure_symlinks(HUB_ENV_PREFIX)
 
     # Run installer plugins last
-    run_plugin_actions(pm, args.plugin)
+    run_plugin_actions(pm)
 
     logger.info("Done!")
 


### PR DESCRIPTION
 In the [`run_plugin_actions`](https://github.com/jupyterhub/the-littlest-jupyterhub/blob/01ba34857dd4e316d839034ae2b3cc400b929964/tljh/installer.py#L399) function, hooks are retrieved from the `plugin_manager`, and the `plugins` argument doesn't seem to be used.

This change removes the unused `plugins` argument.

- [ ] ~Add / update documentation~ (installer internals)
- [ ] Add tests
