### PR TITLE
Make bootstrap_pip_spec test argument optional

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ commands:
 
                     .circleci/integration-test.py run-test \
                     --installer-args "--admin admin:admin" \
-                    -- bootstrap_pip_spec $BOOTSTRAP_PIP_SPEC \
+                    --bootstrap_pip_spec $BOOTSTRAP_PIP_SPEC \
                     basic-tests test_admin_installer.py \
                     << parameters.upgrade >>
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,8 +56,9 @@ commands:
                         BOOTSTRAP_PIP_SPEC=git+https://github.com/$CIRCLE_PROJECT_USERNAME/the-littlest-jupyterhub.git@$CIRCLE_SHA1
                     fi
 
-                    .circleci/integration-test.py run-test basic-tests \
-                    "$BOOTSTRAP_PIP_SPEC" test_hub.py test_install.py test_extensions.py \
+                    .circleci/integration-test.py run-test \
+                    --bootstrap_pip_spec "$BOOTSTRAP_PIP_SPEC" \
+                    basic-tests test_hub.py test_install.py test_extensions.py \
                     << parameters.upgrade >>
     admin_tests:
         parameters:
@@ -76,7 +77,8 @@ commands:
 
                     .circleci/integration-test.py run-test \
                     --installer-args "--admin admin:admin" \
-                    basic-tests $BOOTSTRAP_PIP_SPEC test_admin_installer.py \
+                    -- bootstrap_pip_spec $BOOTSTRAP_PIP_SPEC \
+                    basic-tests test_admin_installer.py \
                     << parameters.upgrade >>
 
     plugin_tests:
@@ -95,8 +97,9 @@ commands:
                     fi
 
                     .circleci/integration-test.py run-test \
+                        --bootstrap_pip_spec $BOOTSTRAP_PIP_SPEC \
                         --installer-args "--plugin /srv/src/integration-tests/plugins/simplest" \
-                        plugins $BOOTSTRAP_PIP_SPEC test_simplest_plugin.py \
+                        plugins test_simplest_plugin.py \
                         << parameters.upgrade >>
 
     bootstrap_checks:

--- a/.circleci/integration-test.py
+++ b/.circleci/integration-test.py
@@ -158,8 +158,8 @@ def main():
     run_test_parser = subparsers.add_parser('run-test')
     run_test_parser.add_argument('--installer-args', default='')
     run_test_parser.add_argument('--upgrade', action='store_true')
+    run_test_parser.add_argument('--bootstrap_pip_spec', nargs='?', default="", type=str)
     run_test_parser.add_argument('test_name')
-    run_test_parser.add_argument('bootstrap_pip_spec')
     run_test_parser.add_argument('test_files', nargs='+')
 
     show_logs_parser = subparsers.add_parser('show-logs')


### PR DESCRIPTION
This makes `bootstrap_pip_spec` an optional argument so that when running the integration tests locally, users won't need to add the empty string as an arg (for the default tljh bootsrap pip spec) or the entire pip spec.
 
-~[ ] Add / update documentation~
 -~[ ] Add tests~

 <!-- Read more about our code-review guidelines at https://the-littlest-jupyterhub.readthedocs.io/en/latest/contributing/code-review.html -->