### PR TITLE
Rename to --bootstrap-pip-spec in the integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ commands:
                     fi
 
                     .circleci/integration-test.py run-test \
-                    --bootstrap_pip_spec "$BOOTSTRAP_PIP_SPEC" \
+                    --bootstrap-pip-spec "$BOOTSTRAP_PIP_SPEC" \
                     basic-tests test_hub.py test_install.py test_extensions.py \
                     << parameters.upgrade >>
     admin_tests:
@@ -77,7 +77,7 @@ commands:
 
                     .circleci/integration-test.py run-test \
                     --installer-args "--admin admin:admin" \
-                    --bootstrap_pip_spec $BOOTSTRAP_PIP_SPEC \
+                    --bootstrap-pip-spec $BOOTSTRAP_PIP_SPEC \
                     basic-tests test_admin_installer.py \
                     << parameters.upgrade >>
 
@@ -97,7 +97,7 @@ commands:
                     fi
 
                     .circleci/integration-test.py run-test \
-                        --bootstrap_pip_spec $BOOTSTRAP_PIP_SPEC \
+                        --bootstrap-pip-spec $BOOTSTRAP_PIP_SPEC \
                         --installer-args "--plugin /srv/src/integration-tests/plugins/simplest" \
                         plugins test_simplest_plugin.py \
                         << parameters.upgrade >>

--- a/.circleci/integration-test.py
+++ b/.circleci/integration-test.py
@@ -158,7 +158,7 @@ def main():
     run_test_parser = subparsers.add_parser('run-test')
     run_test_parser.add_argument('--installer-args', default='')
     run_test_parser.add_argument('--upgrade', action='store_true')
-    run_test_parser.add_argument('--bootstrap_pip_spec', nargs='?', default="", type=str)
+    run_test_parser.add_argument('--bootstrap-pip-spec', nargs='?', default="", type=str)
     run_test_parser.add_argument('test_name')
     run_test_parser.add_argument('test_files', nargs='+')
 

--- a/docs/contributing/tests.rst
+++ b/docs/contributing/tests.rst
@@ -56,10 +56,10 @@ For example, to run all the basic tests, you would write:
 This will run the tests in the three files against the same installation
 of TLJH and report errors.
 
-If you would like to run the tests with a custom pip spec for the bootstrap script, you can use the ``--bootstrap_pip_spec``
+If you would like to run the tests with a custom pip spec for the bootstrap script, you can use the ``--bootstrap-pip-spec``
 parameter:
 
 .. code-block:: bash
 
    .circleci/integration-test.py run-test <name-of-run> <test-file-names> \
-      --bootstrap_pip_spec="git+https://github.com/your-username/the-littlest-jupyterhub.git@branch-name"
+      --bootstrap-pip-spec="git+https://github.com/your-username/the-littlest-jupyterhub.git@branch-name"


### PR DESCRIPTION
Quick follow-up for https://github.com/jupyterhub/the-littlest-jupyterhub/pull/558 and https://github.com/jupyterhub/the-littlest-jupyterhub/pull/563, to keep the style consistent with other parameters such as `--installer-args`.

- [x] Add / update documentation
- [x] Update tests
