### PR TITLE
Add tljh-repo2docker to the list of plugins

### DIFF
--- a/docs/contributing/plugins.rst
+++ b/docs/contributing/plugins.rst
@@ -128,6 +128,8 @@ Here is a non-exhaustive list of known TLJH plugins:
 
 - `tljh-pangeo <https://github.com/yuvipanda/tljh-pangeo>`_: TLJH Plugin for setting up the Pangeo Stack
 - `tljh-voila-gallery <https://github.com/voila-dashboards/tljh-voila-gallery>`_: TLJH plugin that installs a gallery of Voilà dashboards
+- `tljh-repo2docker <https://github.com/plasmabio/tljh-repo2docker>`_: TLJH plugin to build multiple user environments with
+  `repo2docker <https://repo2docker.readthedocs.io>`_.
 
 If you have authored a plugin, please open a PR to add it to this list!
 


### PR DESCRIPTION
Add [tljh-repo2docker](https://github.com/plasmabio/tljh-repo2docker) to the list of known plugins.

This plugin can be used to build multiple user environments with `repo2docker`.

 - [x] Add / update documentation
 - [x] ~Add tests~

 <!-- Read more about our code-review guidelines at https://the-littlest-jupyterhub.readthedocs.io/en/latest/contributing/code-review.html -->