### PR TITLE
Add a useful link to the git repo, fix a typo, in docs

### DIFF
--- a/docs/contributing/dev-setup.rst
+++ b/docs/contributing/dev-setup.rst
@@ -9,7 +9,7 @@ The easiest & safest way to develop & test TLJH is with `Docker <https://www.doc
 #. Install Docker Community Edition by following the instructions on
    `their website <https://www.docker.com/community-edition>`_.
 
-#. Clone the git repo (or your fork of it).
+#. Clone the [git repo](https://github.com/jupyterhub/the-littlest-jupyterhub) (or your fork of it).
 #. Build a docker image that has a functional systemd in it.
 
    .. code-block:: bash

--- a/docs/howto/admin/admin-users.rst
+++ b/docs/howto/admin/admin-users.rst
@@ -13,7 +13,7 @@ Admin users in TLJH have the following powers:
 #. Change configuration of TLJH
 
 This is a lot of power, so make sure you know who you are giving it
-to. Admin users should have decent passwords / secure logni mechanisms,
+to. Admin users should have decent passwords / secure login mechanisms,
 so attackers can not easily gain control of the system.
 
 .. important::


### PR DESCRIPTION
Added a link to the repo in the docs at a useful point.
