### PR TITLE
Use sha256 sums for verifying miniconda download

### DIFF
--- a/tests/test_conda.py
+++ b/tests/test_conda.py
@@ -14,9 +14,10 @@ def prefix():
     Provide a temporary directory with a conda environment
     """
     miniconda_version = '4.7.10'
-    miniconda_installer_md5 = "1c945f2b3335c7b2b15130b1b2dc5cf4"
+    miniconda_installer_sha256 = "8a324adcc9eaf1c09e22a992bb6234d91a94146840ee6b11c114ecadafc68121"
+    installer_url = "https://repo.continuum.io/miniconda/Miniconda3-{}-Linux-x86_64.sh".format(miniconda_version)
     with tempfile.TemporaryDirectory() as tmpdir:
-        with conda.download_miniconda_installer(miniconda_version, miniconda_installer_md5) as installer_path:
+        with conda.download_miniconda_installer(installer_url, miniconda_installer_sha256) as installer_path:
             conda.install_miniconda(installer_path, tmpdir)
         conda.ensure_conda_packages(tmpdir, [
             'conda==4.8.1'

--- a/tljh/conda.py
+++ b/tljh/conda.py
@@ -12,17 +12,17 @@ from distutils.version import LooseVersion as V
 from tljh import utils
 
 
-def md5_file(fname):
+def sha256_file(fname):
     """
-    Return md5 of a given filename
+    Return sha256 of a given filename
 
     Copied from https://stackoverflow.com/a/3431838
     """
-    hash_md5 = hashlib.md5()
+    hash_sha256 = hashlib.sha256()
     with open(fname, "rb") as f:
         for chunk in iter(lambda: f.read(4096), b""):
-            hash_md5.update(chunk)
-    return hash_md5.hexdigest()
+            hash_sha256.update(chunk)
+    return hash_sha256.hexdigest()
 
 
 def check_miniconda_version(prefix, version):
@@ -41,21 +41,20 @@ def check_miniconda_version(prefix, version):
 
 
 @contextlib.contextmanager
-def download_miniconda_installer(version, md5sum):
+def download_miniconda_installer(installer_url, sha256sum):
     """
-    Context manager to download miniconda installer of given version.
+    Context manager to download miniconda installer from a given URL
 
     This should be used as a contextmanager. It downloads miniconda installer
-    of given version, verifies the md5sum & provides path to it to the `with`
+    of given version, verifies the sha256sum & provides path to it to the `with`
     block to run.
     """
     with tempfile.NamedTemporaryFile() as f:
-        installer_url = "https://repo.continuum.io/miniconda/Miniconda3-{}-Linux-x86_64.sh".format(version)
         with open(f.name, 'wb') as f:
             f.write(requests.get(installer_url).content)
 
-        if md5_file(f.name) != md5sum:
-            raise Exception('md5 hash mismatch! Downloaded file corrupted')
+        if sha256_file(f.name) != sha256sum:
+            raise Exception('sha256sum hash mismatch! Downloaded file corrupted')
 
         yield f.name
 

--- a/tljh/installer.py
+++ b/tljh/installer.py
@@ -255,7 +255,7 @@ def ensure_user_environment(user_requirements_txt_file):
 
     miniconda_old_version = '4.5.4'
     miniconda_new_version = '4.7.10'
-    miniconda_installer_md5 = "1c945f2b3335c7b2b15130b1b2dc5cf4"
+    miniconda_installer_sha256 = "8a324adcc9eaf1c09e22a992bb6234d91a94146840ee6b11c114ecadafc68121"
 
     if conda.check_miniconda_version(USER_ENV_PREFIX, miniconda_new_version):
         conda_version = '4.8.1'
@@ -264,7 +264,9 @@ def ensure_user_environment(user_requirements_txt_file):
     # If no prior miniconda installation is found, we can install a newer version
     else:
         logger.info('Downloading & setting up user environment...')
-        with conda.download_miniconda_installer(miniconda_new_version, miniconda_installer_md5) as installer_path:
+        # FIXME: allow using miniforge
+        installer_url = "https://repo.continuum.io/miniconda/Miniconda3-{}-Linux-x86_64.sh".format(miniconda_new_version)
+        with conda.download_miniconda_installer(installer_url, miniconda_installer_sha256) as installer_path:
             conda.install_miniconda(installer_path, USER_ENV_PREFIX)
         conda_version = '4.8.1'
 


### PR DESCRIPTION
miniconda downloader now provides sha256 hashes. Previously
it provided only md5 hashes. md5 is deprecated everywhere for
everything, so let's use this


 - [x] Add tests

 <!-- Read more about our code-review guidelines at https://the-littlest-jupyterhub.readthedocs.io/en/latest/contributing/code-review.html -->