### PR TITLE
Fixed git repo link from markdown to rst

### DIFF
--- a/docs/contributing/dev-setup.rst
+++ b/docs/contributing/dev-setup.rst
@@ -9,7 +9,7 @@ The easiest & safest way to develop & test TLJH is with `Docker <https://www.doc
 #. Install Docker Community Edition by following the instructions on
    `their website <https://www.docker.com/community-edition>`_.
 
-#. Clone the [git repo](https://github.com/jupyterhub/the-littlest-jupyterhub) (or your fork of it).
+#. Clone the `git repo <https://github.com/jupyterhub/the-littlest-jupyterhub>`_ (or your fork of it).
 #. Build a docker image that has a functional systemd in it.
 
    .. code-block:: bash


### PR DESCRIPTION
Update documentation. I actually submitted this as a PR a couple of weeks ago, but managed to get it wrong, sorry!

I gave you a markdown link but it should have been rst...

This time I even ran the doc build and tests...
