### PR TITLE
Use /hub/api endpoint to check for hub ready

### DIFF
--- a/tljh/config.py
+++ b/tljh/config.py
@@ -240,7 +240,7 @@ def remove_config_value(config_path, key_path, value):
 
 def check_hub_ready():
     try:
-        r = requests.get('http://127.0.0.1:80', verify=False)
+        r = requests.get('http://127.0.0.1:80/hub/api', verify=False)
         return r.status_code == 200
     except:
         return False


### PR DESCRIPTION
Use `http://127.0.0.1:80/hub/api` to check for hub ready. The response for the the `/hub/api` endpoint is as follows:

```json
{"version": "1.1.0"}
```

The main motivation for this change is the use of the `LTIAuthenticator` which returns a 405 after it has been configured as mentioned in https://github.com/jupyterhub/ltiauthenticator#edx (step 5).

 - [ ] Add / update documentation
 - [ ] Add tests

 <!-- Read more about our code-review guidelines at https://the-littlest-jupyterhub.readthedocs.io/en/latest/contributing/code-review.html -->