### PR TITLE
docs: follow redirect when downloading bootstap

### DIFF
--- a/.circleci/integration-test.py
+++ b/.circleci/integration-test.py
@@ -100,7 +100,7 @@ def run_test(image_name, test_name, bootstrap_pip_spec, test_files, upgrade, ins
     if upgrade:
         run_container_command(
             test_name,
-            f'curl https://tljh.jupyter.org/bootstrap.py | python3 -'
+            f'curl -L https://tljh.jupyter.org/bootstrap.py | python3 -'
         )
 
     run_container_command(

--- a/docs/howto/auth/awscognito.rst
+++ b/docs/howto/auth/awscognito.rst
@@ -50,7 +50,7 @@ able to configure the instance automatically, replace relevant config variables:
         ##############################################
         # Need to ensure oauthenticator is bumped to 0.10.0
         ##############################################
-        curl https://tljh.jupyter.org/bootstrap.py \
+        curl -L https://tljh.jupyter.org/bootstrap.py \
           | sudo python3 - \
             --admin insightadmin
 

--- a/docs/install/amazon.rst
+++ b/docs/install/amazon.rst
@@ -101,7 +101,7 @@ Let's create the server on which we can run JupyterHub.
    .. code-block:: bash
 
        #!/bin/bash
-       curl https://tljh.jupyter.org/bootstrap.py \
+       curl -L https://tljh.jupyter.org/bootstrap.py \
          | sudo python3 - \
            --admin <admin-user-name>
 

--- a/docs/install/azure.rst
+++ b/docs/install/azure.rst
@@ -135,7 +135,7 @@ A new screen with all the options for Virtual Machines in Azure will displayed.
       .. code:: bash
 
          #!/bin/bash
-         curl https://tljh.jupyter.org/bootstrap.py \
+         curl -L https://tljh.jupyter.org/bootstrap.py \
            | sudo python3 - \
              --admin <admin-user-name>
 

--- a/docs/install/custom-server.rst
+++ b/docs/install/custom-server.rst
@@ -59,7 +59,7 @@ Step 1: Installing The Littlest JupyterHub
 
    .. code-block:: bash
 
-      curl https://tljh.jupyter.org/bootstrap.py | sudo -E python3 - --admin <admin-user-name>
+      curl -L https://tljh.jupyter.org/bootstrap.py | sudo -E python3 - --admin <admin-user-name>
 
    .. note::
 

--- a/docs/install/digitalocean.rst
+++ b/docs/install/digitalocean.rst
@@ -63,7 +63,7 @@ Let's create the server on which we can run JupyterHub.
    .. code-block:: bash
 
       #!/bin/bash
-      curl https://tljh.jupyter.org/bootstrap.py \
+      curl -L https://tljh.jupyter.org/bootstrap.py \
         | sudo python3 - \
           --admin <admin-user-name>
 

--- a/docs/install/google.rst
+++ b/docs/install/google.rst
@@ -144,7 +144,7 @@ Let's create the server on which we can run JupyterHub.
    .. code-block:: bash
 
        #!/bin/bash
-       curl https://tljh.jupyter.org/bootstrap.py \
+       curl -L https://tljh.jupyter.org/bootstrap.py \
          | sudo python3 - \
            --admin <admin-user-name>
 

--- a/docs/install/jetstream.rst
+++ b/docs/install/jetstream.rst
@@ -86,7 +86,7 @@ Let's create the server on which we can run JupyterHub.
    .. code-block:: bash
 
       #!/bin/bash
-      curl https://tljh.jupyter.org/bootstrap.py \
+      curl -L https://tljh.jupyter.org/bootstrap.py \
         | sudo python3 - \
           --admin <admin-user-name>
 

--- a/docs/install/ovh.rst
+++ b/docs/install/ovh.rst
@@ -71,7 +71,7 @@ Let's create the server on which we can run JupyterHub.
    .. code-block:: bash
 
       #!/bin/bash
-      curl https://tljh.jupyter.org/bootstrap.py \
+      curl -L https://tljh.jupyter.org/bootstrap.py \
         | sudo python3 - \
           --admin <admin-user-name>
 

--- a/docs/topic/customizing-installer.rst
+++ b/docs/topic/customizing-installer.rst
@@ -9,7 +9,7 @@ is executed as:
 
 .. code-block:: bash
 
-    curl https://tljh.jupyter.org/bootstrap.py \
+    curl -L https://tljh.jupyter.org/bootstrap.py \
      | sudo python3 - \
        <parameters>
 
@@ -33,7 +33,7 @@ during install you would:
 
 .. code-block:: bash
 
-    curl https://tljh.jupyter.org/bootstrap.py \
+    curl -L https://tljh.jupyter.org/bootstrap.py \
      | sudo python3 - \
        --admin admin-user1:password-user1 --admin admin-user2:password-user2
 
@@ -41,7 +41,7 @@ during install you would:
 
 .. code-block:: bash
 
-    curl https://tljh.jupyter.org/bootstrap.py \
+    curl -L https://tljh.jupyter.org/bootstrap.py \
      | sudo python3 - \
        --admin admin-user1 --admin admin-user2
 
@@ -49,7 +49,7 @@ during install you would:
 
 .. code-block:: bash
 
-    curl https://tljh.jupyter.org/bootstrap.py \
+    curl -L https://tljh.jupyter.org/bootstrap.py \
      | sudo python3 - \
        --admin admin-user1:password-user1 --admin admin-user2
 
@@ -66,7 +66,7 @@ in your new hub, you would run:
 
 .. code-block:: bash
 
-    curl https://tljh.jupyter.org/bootstrap.py \
+    curl -L https://tljh.jupyter.org/bootstrap.py \
      | sudo python3 - \
        --user-requirements-txt-url https://raw.githubusercontent.com/data-8/materials-sp18/master/requirements.txt
 
@@ -97,7 +97,7 @@ you would use:
 
 .. code-block:: bash
 
-   curl https://tljh.jupyter.org/bootstrap.py \
+   curl -L https://tljh.jupyter.org/bootstrap.py \
     | sudo python3 - \
       --plugin git+https://github.com/yuvipanda/tljh-pangeo@v0.1
 


### PR DESCRIPTION
curl https://tljh.jupyter.org/bootstrap.py will just give you an empty
file with curl 7.58.0 (version from Ubuntu 18.04). Adding -L
(--location) instructs curl to follow redirects.

 - [ ] Add / update documentation
 - [ ] Add tests

 <!-- Read more about our code-review guidelines at https://the-littlest-jupyterhub.readthedocs.io/en/latest/contributing/code-review.html -->