### PR TITLE
Add base_url capability to tljh-config

### DIFF
--- a/bootstrap/bootstrap.py
+++ b/bootstrap/bootstrap.py
@@ -292,7 +292,7 @@ def main():
         pip_flags.append('--editable')
     tljh_repo_path = os.environ.get(
         'TLJH_BOOTSTRAP_PIP_SPEC',
-        'git+https://github.com/jeanmarcalkazzi/the-littlest-jupyterhub'
+        'git+https://github.com/jupyterhub/the-littlest-jupyterhub.git'
     )
 
     # Upgrade pip

--- a/bootstrap/bootstrap.py
+++ b/bootstrap/bootstrap.py
@@ -292,7 +292,7 @@ def main():
         pip_flags.append('--editable')
     tljh_repo_path = os.environ.get(
         'TLJH_BOOTSTRAP_PIP_SPEC',
-        'git+https://github.com/jupyterhub/the-littlest-jupyterhub.git'
+        'git+https://github.com/jeanmarcalkazzi/the-littlest-jupyterhub'
     )
 
     # Upgrade pip

--- a/docs/topic/tljh-config.rst
+++ b/docs/topic/tljh-config.rst
@@ -66,7 +66,7 @@ Some of the existing ``<property-path>`` are listed below by categories:
 .. _tljh-base_url:
 
 Base URL
---------------
+--------
 
     Use ``base_url`` to determine the base URL used by JupyterHub. This parameter will 
     be passed straight to ``c.JupyterHub.base_url``.

--- a/docs/topic/tljh-config.rst
+++ b/docs/topic/tljh-config.rst
@@ -63,6 +63,13 @@ file. If what you want is only to change the property's value, you should use
 
 Some of the existing ``<property-path>`` are listed below by categories:
 
+.. _tljh-base_url:
+
+Base URL
+--------------
+
+    Use ``base_url`` to determine the base URL used by JupyterHub. This parameter will 
+    be passed straight to ``c.JupyterHub.base_url``.
 
 .. _tljh-set-auth:
 

--- a/integration-tests/test_hub.py
+++ b/integration-tests/test_hub.py
@@ -48,7 +48,7 @@ async def test_user_code_execute():
 
 
 @pytest.mark.asyncio
-async def test_user_code_execute_with_custom_base_url():
+async def test_user_server_started_with_custom_base_url():
     """
     User logs in, starts a server with a custom base_url & executes code
     """

--- a/tests/test_configurer.py
+++ b/tests/test_configurer.py
@@ -2,6 +2,7 @@
 Test configurer
 """
 
+from traitlets import Dict
 import os
 import sys
 
@@ -60,6 +61,22 @@ def apply_mock_config(overrides):
     c = MockConfigurer()
     configurer.apply_config(overrides, c)
     return c
+
+
+def test_default_base_url():
+    """
+    Test default JupyterHub base_url
+    """
+    c = apply_mock_config({})
+    assert c.JupyterHub.base_url == '/'
+
+
+def test_set_base_url():
+    """
+    Test set JupyterHub base_url
+    """
+    c = apply_mock_config({'base_url': '/custom-base'})
+    assert c.JupyterHub.base_url == '/custom-base'
 
 
 def test_default_memory_limit():
@@ -129,7 +146,7 @@ def test_auth_dummy():
     assert c.JupyterHub.authenticator_class == 'dummyauthenticator.DummyAuthenticator'
     assert c.DummyAuthenticator.password == 'test'
 
-from traitlets import Dict
+
 def test_user_groups():
     """
     Test setting user groups
@@ -143,9 +160,9 @@ def test_user_groups():
         }
     })
     assert c.UserCreatingSpawner.user_groups == {
-                "g1": ["u1", "u2"],
-                "g2": ["u3", "u4"]
-            }
+        "g1": ["u1", "u2"],
+        "g2": ["u3", "u4"]
+    }
 
 
 def test_auth_firstuse():
@@ -213,9 +230,9 @@ def test_cull_service_default():
     c = apply_mock_config({})
 
     cull_cmd = [
-       sys.executable, '-m', 'jupyterhub_idle_culler',
-       '--timeout=600', '--cull-every=60', '--concurrency=5',
-       '--max-age=0'
+        sys.executable, '-m', 'jupyterhub_idle_culler',
+        '--timeout=600', '--cull-every=60', '--concurrency=5',
+        '--max-age=0'
     ]
     assert c.JupyterHub.services == [{
         'name': 'cull-idle',
@@ -238,9 +255,9 @@ def test_set_cull_service():
         }
     })
     cull_cmd = [
-       sys.executable, '-m', 'jupyterhub_idle_culler',
-       '--timeout=600', '--cull-every=10', '--concurrency=5',
-       '--max-age=60', '--cull-users'
+        sys.executable, '-m', 'jupyterhub_idle_culler',
+        '--timeout=600', '--cull-every=10', '--concurrency=5',
+        '--max-age=60', '--cull-users'
     ]
     assert c.JupyterHub.services == [{
         'name': 'cull-idle',
@@ -276,4 +293,3 @@ def test_auth_native():
     })
     assert c.JupyterHub.authenticator_class == 'nativeauthenticator.NativeAuthenticator'
     assert c.NativeAuthenticator.open_signup == True
-

--- a/tljh/config.py
+++ b/tljh/config.py
@@ -61,6 +61,7 @@ def set_item_in_config(config, property_path, value):
 
     return config_copy
 
+
 def unset_item_from_config(config, property_path):
     """
     Unset key at property_path in config & return new config.
@@ -104,6 +105,7 @@ def unset_item_from_config(config, property_path):
             cur_part = cur_part[cur_path]
 
     return config_copy
+
 
 def add_item_to_config(config, property_path, value):
     """
@@ -238,6 +240,7 @@ def remove_config_value(config_path, key_path, value):
     with open(config_path, 'w') as f:
         yaml.dump(config, f)
 
+
 def check_hub_ready():
     from .configurer import load_config
 
@@ -249,6 +252,7 @@ def check_hub_ready():
         return r.status_code == 200
     except:
         return False
+
 
 def reload_component(component):
     """
@@ -392,13 +396,16 @@ def main(argv=None):
     if args.action == 'show':
         show_config(args.config_path)
     elif args.action == 'set':
-        set_config_value(args.config_path, args.key_path, parse_value(args.value))
+        set_config_value(args.config_path, args.key_path,
+                         parse_value(args.value))
     elif args.action == 'unset':
         unset_config_value(args.config_path, args.key_path)
     elif args.action == 'add-item':
-        add_config_value(args.config_path, args.key_path, parse_value(args.value))
+        add_config_value(args.config_path, args.key_path,
+                         parse_value(args.value))
     elif args.action == 'remove-item':
-        remove_config_value(args.config_path, args.key_path, parse_value(args.value))
+        remove_config_value(args.config_path, args.key_path,
+                            parse_value(args.value))
     elif args.action == 'reload':
         reload_component(args.component)
     else:

--- a/tljh/config.py
+++ b/tljh/config.py
@@ -240,9 +240,12 @@ def remove_config_value(config_path, key_path, value):
 
 def check_hub_ready():
     from .configurer import load_config
+
+    base_url = load_config()['base_url']
+    base_url = base_url[:-1] if base_url[-1] == '/' else base_url
     http_port = load_config()['http']['port']
     try:
-        r = requests.get('http://127.0.0.1:%d/hub/api' % http_port, verify=False)
+        r = requests.get('http://127.0.0.1:%d%s/hub/api' % (http_port, base_url), verify=False)
         return r.status_code == 200
     except:
         return False

--- a/tljh/configurer.py
+++ b/tljh/configurer.py
@@ -17,6 +17,7 @@ from .yaml import yaml
 # Default configuration for tljh
 # User provided config is merged into this
 default = {
+    'base_url': '/',
     'auth': {
         'type': 'firstuseauthenticator.FirstUseAuthenticator',
         'FirstUseAuthenticator': {
@@ -69,6 +70,7 @@ default = {
     }
 }
 
+
 def load_config(config_file=CONFIG_FILE):
     """Load the current config as a dictionary
 
@@ -92,6 +94,7 @@ def apply_config(config_overrides, c):
     """
     tljh_config = _merge_dictionaries(dict(default), config_overrides)
 
+    update_base_url(c, tljh_config)
     update_auth(c, tljh_config)
     update_userlists(c, tljh_config)
     update_usergroups(c, tljh_config)
@@ -115,7 +118,7 @@ def load_traefik_api_credentials():
     proxy_secret_path = os.path.join(STATE_DIR, 'traefik-api.secret')
     if not os.path.exists(proxy_secret_path):
         return {}
-    with open(proxy_secret_path,'r') as f:
+    with open(proxy_secret_path, 'r') as f:
         password = f.read()
     return {
         'traefik_api': {
@@ -132,6 +135,13 @@ def load_secrets():
     config = {}
     config = _merge_dictionaries(config, load_traefik_api_credentials())
     return config
+
+
+def update_base_url(c, config):
+    """
+    Update base_url of JupyterHub through tljh config
+    """
+    c.JupyterHub.base_url = config['base_url']
 
 
 def update_auth(c, config):
@@ -218,7 +228,7 @@ def set_cull_idle_service(config):
     Set Idle Culler service
     """
     cull_cmd = [
-       sys.executable, '-m', 'jupyterhub_idle_culler'
+        sys.executable, '-m', 'jupyterhub_idle_culler'
     ]
     cull_config = config['services']['cull']
     print()


### PR DESCRIPTION
This pull request:
* fixes #616 
* fixes #216
* fixes #426

A function update_base_url now sets c.JupyterHub.base_url to the requested value, and correctly checks for it during the check_hub_ready function. 

- [X] Add / update documentation
- [X] Add tests