### PR TITLE
Fix doc build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -52,10 +52,11 @@ if os.path.exists(os.path.join(here, '_static')):
 # and seems to be hard to control.
 html_sidebars = {
     '**': [
-        'about.html',
+        # from pydata_sphinx_theme
+        'sidebar-nav-bs.html',
+        'sidebar-search-bs.html'
+        # from sphinx builtins
         'globaltoc.html',
         'relations.html',
-        'searchbox.html',
-        'donate.html',
     ]
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -54,7 +54,7 @@ html_sidebars = {
     '**': [
         # from pydata_sphinx_theme
         'sidebar-nav-bs.html',
-        'sidebar-search-bs.html'
+        'sidebar-search-bs.html',
         # from sphinx builtins
         'globaltoc.html',
         'relations.html',

--- a/docs/howto/index.rst
+++ b/docs/howto/index.rst
@@ -1,6 +1,30 @@
 How-To Guides
 =============
 
+.. toctree::
+   :hidden:
+
+   content/nbgitpuller
+   content/add-data
+   content/share-data
+   env/user-environment
+   env/notebook-interfaces
+   env/server-resources
+   auth/dummy
+   auth/github
+   auth/google
+   auth/awscognito
+   auth/firstuse
+   auth/nativeauth
+   admin/admin-users
+   admin/resource-estimation
+   admin/resize
+   admin/nbresuse
+   admin/https
+   admin/enable-extensions
+   providers/digitalocean
+   providers/azure
+
 How-To guides answer the question 'How do I...?' for a lot of topics.
 
 Content and Data


### PR DESCRIPTION
The RTD build was failing with [``TemplateNotFound('about.html') error``.](https://readthedocs.org/projects/the-littlest-jupyterhub/builds/12133621/) I believe this was because, before `pydata-sphix-theme v.0.4.1`, there was no `html_sidebars` feature (thanks @choldgraf  for adding it :partying_face:), so it was not complaining that we were still using the sidebars from the old one. Removing the old sidebars and using the ones from the new theme, seams to be fixing the issue.

(This also fixes the left TOC for the `how-to` docs section) 