### PR TITLE
Fix html_sidebars

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,17 +46,3 @@ html_favicon = 'images/logo/favicon.ico'
 here = os.path.dirname(os.path.abspath(__file__))
 if os.path.exists(os.path.join(here, '_static')):
     html_static_path = ['_static']
-
-# Configure the sidebar to be how we want it to be
-# We don't have 'navigation' here, since it is very cluttered
-# and seems to be hard to control.
-html_sidebars = {
-    '**': [
-        # from pydata_sphinx_theme
-        'sidebar-nav-bs.html',
-        'sidebar-search-bs.html',
-        # from sphinx builtins
-        'globaltoc.html',
-        'relations.html',
-    ]
-}


### PR DESCRIPTION
The docs are looking funny because of my last PR https://github.com/jupyterhub/the-littlest-jupyterhub/pull/624 :confused: .
![funny-looking-docs](https://user-images.githubusercontent.com/7579677/96614575-f4a43380-1308-11eb-93c4-8eb3022e7caf.png) 

The `pydata-sphinx-theme` sidebars are enabled by default, there's no need to list them. Having these together with the sphinx `html_sidebars`  builtins, make the docs look funny, like in the screenshot above. So, I believe it is best to stick with the theme's defaults.