### PR TITLE
Bump memory again for integration tests

### DIFF
--- a/.circleci/integration-test.py
+++ b/.circleci/integration-test.py
@@ -32,7 +32,7 @@ def run_systemd_image(image_name, container_name, bootstrap_pip_spec):
         # This is the minimum VM size we support. JupyterLab extensions seem
         # to need at least this much RAM to build. Boo?
         # If we change this, need to change all other references to this number.
-        '--memory', '1.15G',
+        '--memory', '1.5G',
     ]
 
     if bootstrap_pip_spec:

--- a/docs/howto/admin/resource-estimation.rst
+++ b/docs/howto/admin/resource-estimation.rst
@@ -12,7 +12,7 @@ Memory
 ======
 
 Memory is usually the biggest determinant of server size in most JupyterHub
-installations. At minimum, your server must have at least **1.15GB** of RAM
+installations. At minimum, your server must have at least **1.5GB** of RAM
 for TLJH to install.
 
 .. math::

--- a/docs/install/amazon.rst
+++ b/docs/install/amazon.rst
@@ -79,7 +79,7 @@ Let's create the server on which we can run JupyterHub.
    `Next: Configure Instance Details` in the lower right corner.  
    
    Check out our guide on How To :ref:`howto/admin/resource-estimation` to help pick
-   how much Memory / CPU your server needs. You need to have at least **1.15GB** of
+   how much Memory / CPU your server needs. You need to have at least **1.5GB** of
    RAM.
    
    You may wish to consult the listing `here <https://www.ec2instances.info/>`_ 

--- a/docs/install/custom-server.rst
+++ b/docs/install/custom-server.rst
@@ -32,7 +32,7 @@ Pre-requisites
 
 #. Some familiarity with the command line.
 #. A server running Ubuntu 18.04 where you have root access.
-#. At least **1.15GB** of RAM on your server.
+#. At least **1.5GB** of RAM on your server.
 #. Ability to ``ssh`` into the server & run commands from the prompt.
 #. A **IP address** where the server can be reached from the browsers of your target audience.
 

--- a/docs/install/google.rst
+++ b/docs/install/google.rst
@@ -69,7 +69,7 @@ Let's create the server on which we can run JupyterHub.
 #. For **Zone**, pick any of the options. Leaving the default as is is fine.
 
 #. Under **Machine** type, select the amount of CPU / RAM / GPU you want for your
-   server. You need at least **1.15GB** of RAM.
+   server. You need at least **1.5GB** of RAM.
 
    You can select a preset combination in the default **basic view**.
 

--- a/docs/install/jetstream.rst
+++ b/docs/install/jetstream.rst
@@ -53,7 +53,7 @@ Let's create the server on which we can run JupyterHub.
 
    #. Give your server a descriptive **Instance Name**.
    #. Select an appropriate **Instance Size**. We suggest m1.medium or larger.
-      Make sure your instance has at least **1.15GB** of RAM.
+      Make sure your instance has at least **1.5GB** of RAM.
 
       Check out our guide on How To :ref:`howto/admin/resource-estimation` to help pick
       how much Memory, CPU & disk space your server needs.


### PR DESCRIPTION
Tests are failing *again* probably because of not enough memory. We've had this issue before :confused: 

This bumps the mem to 1.5G. Hope it'll be enough

 <!-- Read more about our code-review guidelines at https://the-littlest-jupyterhub.readthedocs.io/en/latest/contributing/code-review.html -->