### PR TITLE
Pin chardet

### DIFF
--- a/integration-tests/test_proxy.py
+++ b/integration-tests/test_proxy.py
@@ -165,7 +165,7 @@ def test_extra_traefik_config():
     # test extra dynamic config
     resp = send_request(url="http://127.0.0.1/the/hub/runs/here/too", max_sleep=5)
     assert resp.code == 200
-    assert resp.effective_url == "http://127.0.0.1/hub/login"
+    assert "http://127.0.0.1/hub/login" in resp.effective_url
 
     # cleanup
     os.remove(os.path.join(extra_static_config_dir, "extra.toml"))

--- a/tljh/installer.py
+++ b/tljh/installer.py
@@ -222,7 +222,7 @@ def ensure_jupyterhub_package(prefix):
     conda.ensure_pip_packages(
         prefix,
         [
-            "jupyterhub==1.2.0",
+            "jupyterhub==1.2.2",
             "jupyterhub-dummyauthenticator==0.3.1",
             "jupyterhub-systemdspawner==0.15",
             "jupyterhub-firstuseauthenticator==0.14.1",
@@ -231,6 +231,7 @@ def ensure_jupyterhub_package(prefix):
             "jupyterhub-tmpauthenticator==0.6",
             "oauthenticator==0.10.0",
             "jupyterhub-idle-culler==1.0",
+            "chardet==3.0.4",
         ],
     )
     traefik.ensure_traefik_binary(prefix)

--- a/tljh/installer.py
+++ b/tljh/installer.py
@@ -222,7 +222,7 @@ def ensure_jupyterhub_package(prefix):
     conda.ensure_pip_packages(
         prefix,
         [
-            "jupyterhub==1.1.0",
+            "jupyterhub==1.2.0",
             "jupyterhub-dummyauthenticator==0.3.1",
             "jupyterhub-systemdspawner==0.15",
             "jupyterhub-firstuseauthenticator==0.14.1",


### PR DESCRIPTION
* Pin `chardet` in the hub environment to a version that doesn't conflict with traefik-proxy's `aiohttp` requirement until we figure out what is going on.
* Bump the `jupyterhub` version in the hub env to the same version in the user env

Reported in https://github.com/jupyterhub/the-littlest-jupyterhub/issues/642

 <!-- Read more about our code-review guidelines at https://the-littlest-jupyterhub.readthedocs.io/en/latest/contributing/code-review.html -->