### PR TITLE
Upgrade to JupyterLab 3.0

### DIFF
--- a/integration-tests/test_extensions.py
+++ b/integration-tests/test_extensions.py
@@ -13,7 +13,7 @@ def test_serverextensions():
     ], stderr=subprocess.PIPE)
 
     extensions = [
-        'jupyterlab 2.',
+        'jupyterlab 3.',
         'nbgitpuller 0.9.',
         'nteract_on_jupyter 2.1.',
         'nbresuse '

--- a/tljh/installer.py
+++ b/tljh/installer.py
@@ -166,36 +166,6 @@ def ensure_jupyterhub_service(prefix):
     systemd.enable_service('traefik')
 
 
-def ensure_jupyterlab_extensions():
-    """
-    Install the JupyterLab extensions we want.
-    """
-    extensions = [
-        # We don't pin versions here, since labextension will find something
-        # appropriate for our version of jupyterlab
-        '@jupyter-widgets/jupyterlab-manager'
-    ]
-    install_options = [
-        '--no-build'   # do not build extension at install time. Will build later
-    ]
-    utils.run_subprocess([
-        os.path.join(USER_ENV_PREFIX, 'bin/jupyter'),
-        'labextension',
-        'install'
-    ] + extensions + install_options)
-
-    # Build all the lab extensions in one go using jupyter lab build command
-    build_options = [
-        '--minimize=False',
-        '--dev-build=False'
-    ]
-
-    utils.run_subprocess([
-        os.path.join(USER_ENV_PREFIX, 'bin/jupyter'),
-        'lab',
-        'build'
-    ] + build_options)
-
 
 def ensure_jupyterhub_package(prefix):
     """
@@ -508,7 +478,6 @@ def main():
     logger.info("Setting up JupyterHub...")
     ensure_node()
     ensure_jupyterhub_package(HUB_ENV_PREFIX)
-    ensure_jupyterlab_extensions()
 
     # Stop the http server with the progress page before traefik starts
     if args.progress_page_server_pid:

--- a/tljh/requirements-base.txt
+++ b/tljh/requirements-base.txt
@@ -5,8 +5,10 @@
 jupyterhub==1.2.*
 notebook==6.1.*
 # Install additional notebook frontends!
-jupyterlab==2.*
+jupyterlab==3.*
 nteract-on-jupyter==2.1.*
+# Install jupyterlab extensions from PyPI
+jupyterlab-widgets==1.*
 # nbgitpuller for easily pulling in Git repositories
 nbgitpuller==0.9.*
 # nbresuse to show people how much RAM they are using


### PR DESCRIPTION
JupyterLab 3.0 no longer equires npm to build extensions!
This should hopefully let us reduce the memory requiremets
for TLJH.