### PR TITLE
Fix link to resource estimation in server requirements docs

### DIFF
--- a/docs/topic/requirements.rst
+++ b/docs/topic/requirements.rst
@@ -26,4 +26,4 @@ about how to get HTTP traffic from the world into your server.
 CPU / Memory / Disk Space
 =========================
 
-See how to ref:`howto/admin/resource-estimation`
+See how to :ref:`howto/admin/resource-estimation`


### PR DESCRIPTION
It looks like the link to the resource estimation page was not showing in:

https://tljh.jupyter.org/en/latest/topic/requirements.html?#cpu-memory-disk-space

### Before

![image](https://user-images.githubusercontent.com/591645/104938300-2af85a00-59af-11eb-99ec-f06f1bbeeac3.png)


### After

![image](https://user-images.githubusercontent.com/591645/104938267-20d65b80-59af-11eb-98c2-05e91adced69.png)


 - [x] Add / update documentation
 - [ ] ~Add tests~

 <!-- Read more about our code-review guidelines at https://the-littlest-jupyterhub.readthedocs.io/en/latest/contributing/code-review.html -->