### PR TITLE
Own server install sets admin password in step 3

### DIFF
--- a/docs/install/custom-server.rst
+++ b/docs/install/custom-server.rst
@@ -75,7 +75,7 @@ Step 1: Installing The Littlest JupyterHub
    .. image:: ../images/first-login.png
       :alt: JupyterHub log-in page
 
-#. Login using the **admin user name** you used in step 2. You can choose any
+#. Login using the **admin user name** you used in step 3. You can choose any
    password that you wish. Use a
    strong password & note it down somewhere, since this will be the password for
    the admin user account from now on.


### PR DESCRIPTION
Fix the install instructions for own server setup where it said that 
the password was set in step 2 instead of 3.

 - [x] Add / update documentation
 - [x] Add tests

 <!-- Read more about our code-review guidelines at https://the-littlest-jupyterhub.readthedocs.io/en/latest/contributing/code-review.html -->