### PR TITLE
Added instructions for restarting JupyterHub to docs (re: #455)

### DIFF
--- a/docs/troubleshooting/index.rst
+++ b/docs/troubleshooting/index.rst
@@ -10,6 +10,7 @@ guides help you find what is broken & hopefully fix it.
    :caption: Troubleshooting
 
    logs
+   restart
 
 Often, your issues are not related to TLJH itself but to the cloud provider
 your server is running on. We have some documentation on common issues you

--- a/docs/troubleshooting/restart.rst
+++ b/docs/troubleshooting/restart.rst
@@ -1,0 +1,31 @@
+
+=============================================
+Stopping and Restarting the JupyterHub Server
+=============================================
+
+The user can **stop** the JupyterHub server using:
+
+.. code-block:: console
+
+     $ systemctl stop jupyterhub.service
+
+.. warning:: 
+
+    Keep in mind that other services that may also require stopping:
+
+    * The user's Jupyter server: jupyter-username.service
+    * Traefik.service
+
+The user may **restart** JupyterHub and Traefik services by running:
+
+.. code-block:: console
+
+     $ tljh-config reload proxy
+
+This calls systemctl and restarts Traefik. The user may call systemctl and restart only the JupyterHub using the command: 
+
+.. code-block:: console
+
+     $ tljh-config reload hub
+
+


### PR DESCRIPTION
In the Troubleshooting section of the docs I created a file restart.rst with the instructions for stopping and restarting JupyterHub in response to issue #455. I linked to this document in the troubleshooting index.rst. 

I made this contribution as part of PyCascades sprints. I have never used JupyterHub or restructured text before, so someone should confirm the content is correct and formatted correctly. I did my best to follow the formatting in the other docs. 

 - [ ] Add / update documentation
 - [ ] Add tests

 <!-- Read more about our code-review guidelines at https://the-littlest-jupyterhub.readthedocs.io/en/latest/contributing/code-review.html -->