### PR TITLE
Pin chardet again and pin it for tests also.

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,3 +2,4 @@ pytest
 pytest-cov
 pytest-mock
 codecov
+chardet==3.0.4

--- a/tljh/installer.py
+++ b/tljh/installer.py
@@ -231,6 +231,7 @@ def ensure_jupyterhub_package(prefix):
             "jupyterhub-tmpauthenticator==0.6",
             "oauthenticator==0.10.0",
             "jupyterhub-idle-culler==1.0",
+            "chardet==3.0.4",
         ],
     )
     traefik.ensure_traefik_binary(prefix)


### PR DESCRIPTION
We still need to pin chardet because the aiohttp latest version still has a requirement of chardet<4.
Let's wait until a new aiohttp release before removing our version pins

 - [ ] Add / update documentation
 - [ ] Add tests

 <!-- Read more about our code-review guidelines at https://the-littlest-jupyterhub.readthedocs.io/en/latest/contributing/code-review.html -->