### PR TITLE
Reflect the fact that AWS free tier is not enough

### DIFF
--- a/docs/install/amazon.rst
+++ b/docs/install/amazon.rst
@@ -14,9 +14,6 @@ Prerequisites
 
 #. An Amazon Web Services account.
 
-   The `AWS free tier <https://aws.amazon.com/free/>`_ is fully
-   capable of running a minimal littlest Jupyterhub for testing purposes. 
-
    If asked to choose a default region, choose the one closest to the majority 
    of your users.
 


### PR DESCRIPTION
The AWS free tier covers only a t2.micro instance, which is unsufficient (nowadays?) for installing TLJH.