### PR TITLE
ci: add .readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,29 @@
+# Configuration on how ReadTheDocs (RTD) builds our documentation
+# ref: https://readthedocs.org/projects/the-littlest-jupyterhub/
+# ref: https://docs.readthedocs.io/en/stable/config-file/v2.html
+
+# Required (RTD configuration version)
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.9"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats: []
+
+python:
+  install:
+    # WARNING: This requirements file will be installed without the pip
+    #          --upgrade flag in an existing environment. This means that if a
+    #          package is specified without a lower boundary, we may end up
+    #          accepting the existing version.
+    #
+    #          ref: https://github.com/readthedocs/readthedocs.org/blob/0e3df509e7810e46603be47d268273c596e68455/readthedocs/doc_builder/python_environments.py#L335-L344
+    - requirements: docs/requirements.txt


### PR DESCRIPTION
I added a .readthedocs.yaml file that doesn't really change much, but it makes it clearer that we are using readthedocs to build our docs from the repo.

One small change I think is nice, is to _not build_ a PDF file. It can make search hits go to that instead of the website which is in my mind unwanted, and it can also make builds fail sometimes due to the pdf/epub builder had issues while the html builder didn't due to some dependency etc.