### PR TITLE
Update firstuseauthenticator to 1.0.0

### DIFF
--- a/tljh/installer.py
+++ b/tljh/installer.py
@@ -131,7 +131,7 @@ def ensure_jupyterhub_package(prefix):
         [
             "jupyterhub==1.*",
             "jupyterhub-systemdspawner==0.15.*",
-            "jupyterhub-firstuseauthenticator==0.14.*",
+            "jupyterhub-firstuseauthenticator==1.*",
             "jupyterhub-nativeauthenticator==1.*",
             "jupyterhub-ldapauthenticator==1.*",
             "jupyterhub-tmpauthenticator==0.6.*",


### PR DESCRIPTION
This includes a critical security fix for firstuseauthenticator, and bugfixes for firstuseauthenticator.

- Relate security fix: https://github.com/jupyterhub/firstuseauthenticator/security/advisories/GHSA-5xvc-vgmp-jgc3
- Closes #691 ( bugfix )
- Closes #738