### PR TITLE
launch on lab by default

### DIFF
--- a/tljh/configurer.py
+++ b/tljh/configurer.py
@@ -49,7 +49,7 @@ default = {
         "password": "",
     },
     "user_environment": {
-        "default_app": "classic",
+        "default_app": "jupyterlab",
     },
     "services": {
         "cull": {
@@ -228,6 +228,8 @@ def update_user_environment(c, config):
     # Set default application users are launched into
     if user_env["default_app"] == "jupyterlab":
         c.Spawner.default_url = "/lab"
+    elif user_env["default_app"] == "classic":
+        c.Spawner.default_url = "/tree"        
     elif user_env["default_app"] == "nteract":
         c.Spawner.default_url = "/nteract"
 


### PR DESCRIPTION
- [ ] Add / update documentation
- [ ] Add tests

 <!-- Read more about our code-review guidelines at https://the-littlest-jupyterhub.readthedocs.io/en/latest/contributing/code-review.html -->

Related to https://github.com/jupyterhub/the-littlest-jupyterhub/issues/773.

I'm not sure the mappings between `default_app` and `default_url`. Am I right that there is also `jupyter-labhub` e.g. https://github.com/manics/jupyterhub-rtc-example/blob/main/jupyterhub_config.py#L33
