### PR TITLE
Launch into `/lab` by default by changing TLJH config's default value

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -74,6 +74,32 @@ myst_enable_extensions = [
     "fieldlist",
 ]
 
+
+# -- Options for intersphinx extension ---------------------------------------
+# ref: https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html#configuration
+#
+# The extension makes us able to link like to other projects like below.
+#
+#     rST  - :external:py:class:`jupyterhub.spawner.Spawner`
+#     MyST - {external:py:class}`jupyterhub.spawner.Spawner`
+#
+#     rST  - :external:py:attribute:`jupyterhub.spawner.Spawner.default_url`
+#     MyST - {external:py:attribute}`jupyterhub.spawner.Spawner.default_url`
+#
+# To see what we can link to, do the following where "objects.inv" is appended
+# to the sphinx based website:
+#
+#     python -m sphinx.ext.intersphinx https://jupyterhub.readthedocs.io/en/stable/objects.inv
+#
+intersphinx_mapping = {
+    "jupyterhub": ("https://jupyterhub.readthedocs.io/en/stable/", None),
+}
+
+# intersphinx_disabled_reftypes set based on recommendation in
+# https://docs.readthedocs.io/en/stable/guides/intersphinx.html#using-intersphinx
+intersphinx_disabled_reftypes = ["*"]
+
+
 # -- Options for linkcheck builder -------------------------------------------
 # ref: https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-the-linkcheck-builder
 #

--- a/docs/howto/user-env/notebook-interfaces.md
+++ b/docs/howto/user-env/notebook-interfaces.md
@@ -1,49 +1,47 @@
 (howto/user-env/notebook-interfaces)=
 
-# Change default User Interface
+# Change default user interface
 
-By default, logging into TLJH puts you in the classic Jupyter Notebook
-interface we all know and love. However, there are at least two other
-popular notebook interfaces you can use:
+By default a user starting a server will see the JupyterLab interface. This can
+be changed with TLJH config `user_environment.default_app` or with the
+JupyterHub config
+{external:py:attribute}`jupyterhub.spawner.Spawner.default_url` directly.
 
-1.  [JupyterLab](http://jupyterlab.readthedocs.io/en/stable/)
-2.  [nteract](https://nteract.io/)
+The TLJH config supports the options `jupyterlab` and `classic`, which
+translates to a `Spawner.default_url` config of `/lab` and `/tree`.
 
-Both these interfaces are also shipped with TLJH by default. You can try
-them temporarily, or set them to be the default interface whenever you
-login.
+Both these interfaces are also shipped with TLJH by default. You can try them
+temporarily, or set them to be the default interface whenever you login.
 
 ## Trying an alternate interface temporarily
 
-When you log in & start your server, by default the URL in your browser
-will be something like `/user/<username>/tree`. The `/tree` is what
-tells the notebook server to give you the classic notebook interface.
+When you log in and start your server, by default the URL in your browser will
+be something like `/user/<username>/lab`. The `/lab` is what tells the jupyter
+server to give you the JupyterLab user interface.
 
-- **For the JupyterLab interface**: change `/tree` to `/lab`.
-- **For the nteract interface**: change `/tree` to `/nteract`
+As an example, you can update the URL to not end with `/lab`, but instead end
+with `/tree` to temporarily switch to the classic interface.
 
-You can play around with them and see what fits your use cases best.
+## Changing the default user interface using TLJH config
 
-## Changing the default user interface
+You can change the default url, and therefore the interface users get when they
+log in by modifying TLJH config as an admin user.
 
-You can change the default interface users get when they log in by
-modifying `config.yaml` as an admin user.
+1.  To launch the classic notebook interface when users log in, run the
+    following in the admin console:
 
-1.  To launch **JupyterLab** when users log in, run the following in an
-    admin console:
+    ```bash
+    sudo tljh-config set user_environment.default_app classic
+    ```
+
+1.  To launch JupyterLab when users log in, run the following in an admin
+    console:
 
     ```bash
     sudo tljh-config set user_environment.default_app jupyterlab
     ```
 
-2.  Alternatively, to launch **nteract** when users log in, run the
-    following in the admin console:
-
-    ```bash
-    sudo tljh-config set user_environment.default_app nteract
-    ```
-
-3.  Apply the changes by restarting JupyterHub. This should not disrupt
+1.  Apply the changes by restarting JupyterHub. This should not disrupt
     current users.
 
     ```bash

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- The default user interface changed to JupyterLab, to restore previous behavior
+  see the documentation about [User interfaces](#howto/user-env/notebook-interfaces).
+
 ## 1.0
 
 ### 1.0.0b1 - 2023-07-07

--- a/tests/test_configurer.py
+++ b/tests/test_configurer.py
@@ -62,12 +62,12 @@ def test_app_default():
     assert "default_url" not in c.Spawner
 
 
-def test_app_jupyterlab():
+def test_app_classic():
     """
-    Test setting JupyterLab as default application
+    Test setting classic as default application
     """
-    c = apply_mock_config({"user_environment": {"default_app": "jupyterlab"}})
-    assert c.Spawner.default_url == "/lab"
+    c = apply_mock_config({"user_environment": {"default_app": "classic"}})
+    assert c.Spawner.default_url == "/tree"
 
 
 def test_auth_default():

--- a/tests/test_configurer.py
+++ b/tests/test_configurer.py
@@ -58,8 +58,7 @@ def test_app_default():
     Test default application with no config overrides.
     """
     c = apply_mock_config({})
-    # default_url is not set, so JupyterHub will pick default.
-    assert "default_url" not in c.Spawner
+    assert c.Spawner.default_url == "/lab"
 
 
 def test_app_classic():

--- a/tljh/configurer.py
+++ b/tljh/configurer.py
@@ -52,7 +52,7 @@ default = {
         "password": "",
     },
     "user_environment": {
-        "default_app": "classic",
+        "default_app": "jupyterlab",
     },
     "services": {
         "cull": {
@@ -231,6 +231,8 @@ def update_user_environment(c, config):
     # Set default application users are launched into
     if user_env["default_app"] == "jupyterlab":
         c.Spawner.default_url = "/lab"
+    elif user_env["default_app"] == "classic":
+        c.Spawner.default_url = "/tree"
 
 
 def update_user_account_config(c, config):


### PR DESCRIPTION
This PR changes the default value for the TLJH config `user_environment.default_app` to `jupyterlab`, which makes `c.Spawner.default_url` be set to `/lab` by default in TLJH.

To revert to the behavior before this, a TLJH admin can do:

```
sudo tljh-config set user_environment.default_app classic
```

---

- [x] Add / update documentation
- [x] Add tests

Closes https://github.com/jupyterhub/the-littlest-jupyterhub/issues/773

