### PR TITLE
add info line saying TLJH setup complete

### DIFF
--- a/bootstrap/bootstrap.py
+++ b/bootstrap/bootstrap.py
@@ -389,7 +389,8 @@ def main():
     # Run TLJH installer
     logger.info("Running TLJH installer...")
     os.execv(python_bin, [python_bin, "-m", "tljh.installer"] + tljh_installer_flags)
-
+    logger.info("TLJH setup complete")
+    
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
When looking at the logs i'm not sure when the setup has finished as the last line is `logger.info("Running TLJH installer...")`. This PR adds the line `logger.info("TLJH setup complete")` so myself and others know we can go have fun

 <!-- Read more about our code-review guidelines at https://the-littlest-jupyterhub.readthedocs.io/en/latest/contributing/code-review.html -->
