### PR TITLE
bump jupyterhub to 2.*

### DIFF
--- a/tljh/requirements-base.txt
+++ b/tljh/requirements-base.txt
@@ -6,7 +6,7 @@
 #          our integration tests fail.
 #
 # JupyterHub + notebook package are base requirements for user environment
-jupyterhub==1.*
+jupyterhub==2.*
 notebook==6.*
 # Install additional notebook frontends!
 jupyterlab==3.*


### PR DESCRIPTION
- [ ] Add / update documentation
- [ ] Add tests

 <!-- Read more about our code-review guidelines at https://the-littlest-jupyterhub.readthedocs.io/en/latest/contributing/code-review.html -->

Firstly, does it still work?
Secondly, any reason why not?
