### PR TITLE
DOC: move link to contributing/plugin higher

### DIFF
--- a/docs/topic/customizing-installer.rst
+++ b/docs/topic/customizing-installer.rst
@@ -113,7 +113,8 @@ Installing TLJH plugins
 The Littlest JupyterHub can install additional *plugins* that provide additional
 features. They are most commonly used to install a particular *stack* - such as
 the `PANGEO Stack <https://github.com/yuvipanda/tljh-pangeo>`_ for earth sciences
-research, a stack for a particular class, etc.
+research, a stack for a particular class, etc. You can find more information and
+a list of existing plugins at :ref:`contributing/plugins`.
 
 ``--plugin <plugin-to-install>`` installs and activates a plugin. You can pass it
 however many times you want. Since plugins are distributed as python packages,
@@ -132,8 +133,6 @@ you would use:
 
 
 Multiple plugins can be installed at once with: ``--plugin <first-plugin-to-install> <second-plugin-to-install>``.
-
-See :ref:`contributing/plugins` for more information about plugins.
 
 .. note::
 

--- a/docs/topic/customizing-installer.rst
+++ b/docs/topic/customizing-installer.rst
@@ -113,8 +113,8 @@ Installing TLJH plugins
 The Littlest JupyterHub can install additional *plugins* that provide additional
 features. They are most commonly used to install a particular *stack* - such as
 the `PANGEO Stack <https://github.com/yuvipanda/tljh-pangeo>`_ for earth sciences
-research, a stack for a particular class, etc. You can find more information and
-a list of existing plugins at :ref:`contributing/plugins`.
+research, a stack for a particular class, etc. You can find more information about
+writing plugins and a list of existing plugins at :ref:`contributing/plugins`.
 
 ``--plugin <plugin-to-install>`` installs and activates a plugin. You can pass it
 however many times you want. Since plugins are distributed as python packages,
@@ -122,8 +122,8 @@ however many times you want. Since plugins are distributed as python packages,
 ``plugin-name-on-pypi==<version>`` and ``git+https://github.com/user/repo@tag``
 are the most popular ones. Specifying a version or tag is highly recommended.
 
-For example, to install the PANGEO Plugin version 0.1 in your new TLJH install,
-you would use:
+For example, to install the PANGEO Plugin version 0.1 (if version 0.1 existed)
+in your new TLJH install, you would use:
 
 .. code-block:: bash
 


### PR DESCRIPTION
I'll confess I didn't find this section until I came across https://github.com/jupyterhub/the-littlest-jupyterhub/pull/551

This PR moves the link higher up in the section to get more visibility. It also gives more context about what is on that page.

I also made a note that `git+https://github.com/yuvipanda/tljh-pangeo@v0.1` doesn't exist as I may not be the only person to copy and paste and get an error.
