### PR TITLE
Specify user-environment Python version

### DIFF
--- a/docs/topic/customizing-installer.rst
+++ b/docs/topic/customizing-installer.rst
@@ -120,7 +120,7 @@ you would use:
 
    curl -L https://tljh.jupyter.org/bootstrap.py \
     | sudo python3 - \
-      --python-version 3.7.10
+      --user-python-version 3.7.10
 
 Installing TLJH plugins
 =======================

--- a/docs/topic/customizing-installer.rst
+++ b/docs/topic/customizing-installer.rst
@@ -107,6 +107,21 @@ will fail.
    When pointing to a file on GitHub, make sure to use the 'Raw' version. It should point to
    ``raw.githubusercontent.com``, not ``github.com``.
 
+Specifying the user-environment Python version
+=======================
+
+By default the user environment is provisioned with the latest version of Python 3.9,
+though it is possible to specify a specific Python version if desired.
+
+For example, to set Python version 3.7.10 for the user environment,
+you would use:
+
+.. code-block:: bash
+
+   curl -L https://tljh.jupyter.org/bootstrap.py \
+    | sudo python3 - \
+      --python-version 3.7.10
+
 Installing TLJH plugins
 =======================
 

--- a/tljh/installer.py
+++ b/tljh/installer.py
@@ -180,6 +180,7 @@ def ensure_user_environment(user_requirements_txt_file, user_python_version):
     # Keep these in sync with tests/test_conda.py::prefix
     mambaforge_conda_new_version = "4.10.3"
     mambaforge_mamba_version = "0.16.0"
+    user_python_version = user_python_version if user_python_version else "3.9.*"
 
     if conda.check_miniconda_version(USER_ENV_PREFIX, mambaforge_conda_new_version):
         conda_version = "4.10.3"
@@ -441,7 +442,7 @@ def main():
     )
     argparser.add_argument(
         "--python-version",
-        default="3.9.*", help="Set user-environment Python version",
+        help="Set user-environment Python version",
     )
 
     args = argparser.parse_args()

--- a/tljh/installer.py
+++ b/tljh/installer.py
@@ -153,7 +153,7 @@ def ensure_usergroups():
         f.write("Defaults exempt_group = jupyterhub-admins\n")
 
 
-def ensure_user_environment(user_requirements_txt_file, python_version):
+def ensure_user_environment(user_requirements_txt_file, user_python_version):
     """
     Set up user conda environment with required packages
     """
@@ -180,7 +180,6 @@ def ensure_user_environment(user_requirements_txt_file, python_version):
     # Keep these in sync with tests/test_conda.py::prefix
     mambaforge_conda_new_version = "4.10.3"
     mambaforge_mamba_version = "0.16.0"
-    python_version = python_version if python_version else "3.9.*"
 
     if conda.check_miniconda_version(USER_ENV_PREFIX, mambaforge_conda_new_version):
         conda_version = "4.10.3"
@@ -206,7 +205,7 @@ def ensure_user_environment(user_requirements_txt_file, python_version):
             # Conda's latest version is on conda much more so than on PyPI.
             "conda==" + conda_version,
             "mamba==" + mambaforge_mamba_version,
-            "python==" + python_version  
+            "python==" + user_python_version,
         ],
     )
 
@@ -442,7 +441,7 @@ def main():
     )
     argparser.add_argument(
         "--python-version",
-        help="Set user-environment Python version",
+        default="3.9.*", help="Set user-environment Python version",
     )
 
     args = argparser.parse_args()
@@ -452,7 +451,7 @@ def main():
     ensure_config_yaml(pm)
     ensure_admins(args.admin)
     ensure_usergroups()
-    ensure_user_environment(args.user_requirements_txt_url, args.python_version)
+    ensure_user_environment(args.user_requirements_txt_url, args.user_python_version)
 
     logger.info("Setting up JupyterHub...")
     ensure_jupyterhub_package(HUB_ENV_PREFIX)

--- a/tljh/installer.py
+++ b/tljh/installer.py
@@ -440,6 +440,10 @@ def main():
         type=int,
         help="The pid of the progress page server",
     )
+    argparser.add_argument(
+        "--python-version",
+        help="Set user-environment Python version",
+    )
 
     args = argparser.parse_args()
 

--- a/tljh/installer.py
+++ b/tljh/installer.py
@@ -153,7 +153,7 @@ def ensure_usergroups():
         f.write("Defaults exempt_group = jupyterhub-admins\n")
 
 
-def ensure_user_environment(user_requirements_txt_file):
+def ensure_user_environment(user_requirements_txt_file, python_version):
     """
     Set up user conda environment with required packages
     """
@@ -180,6 +180,7 @@ def ensure_user_environment(user_requirements_txt_file):
     # Keep these in sync with tests/test_conda.py::prefix
     mambaforge_conda_new_version = "4.10.3"
     mambaforge_mamba_version = "0.16.0"
+    python_version = python_version if python_version else "3.9.*"
 
     if conda.check_miniconda_version(USER_ENV_PREFIX, mambaforge_conda_new_version):
         conda_version = "4.10.3"
@@ -205,6 +206,7 @@ def ensure_user_environment(user_requirements_txt_file):
             # Conda's latest version is on conda much more so than on PyPI.
             "conda==" + conda_version,
             "mamba==" + mambaforge_mamba_version,
+            "python==" + python_version  
         ],
     )
 
@@ -446,7 +448,7 @@ def main():
     ensure_config_yaml(pm)
     ensure_admins(args.admin)
     ensure_usergroups()
-    ensure_user_environment(args.user_requirements_txt_url)
+    ensure_user_environment(args.user_requirements_txt_url, args.python_version)
 
     logger.info("Setting up JupyterHub...")
     ensure_jupyterhub_package(HUB_ENV_PREFIX)

--- a/tljh/installer.py
+++ b/tljh/installer.py
@@ -441,7 +441,7 @@ def main():
         help="The pid of the progress page server",
     )
     argparser.add_argument(
-        "--python-version",
+        "--user-python-version",
         help="Set user-environment Python version",
     )
 


### PR DESCRIPTION
- [x] Add / update documentation
- [ ] Add tests

I  am suggesting this feature as I think that it's useful to enable the ability to specify a specific Python version for the User Environment, and this is a specific pain point that I encountered.