### PR TITLE
github workflow: echo $BOOTSTRAP_PIP_SPEC

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -148,7 +148,8 @@ jobs:
       #   GitHub branch for example.
       - name: Set BOOTSTRAP_PIP_SPEC value
         run: |
-          echo "BOOTSTRAP_PIP_SPEC=git+https://github.com/$GITHUB_REPOSITORY.git@$GITHUB_REF" >> $GITHUB_ENV
+          BOOTSTRAP_PIP_SPEC="git+https://github.com/$GITHUB_REPOSITORY.git@$GITHUB_REF"
+          echo "BOOTSTRAP_PIP_SPEC=$BOOTSTRAP_PIP_SPEC" >> $GITHUB_ENV
           echo $BOOTSTRAP_PIP_SPEC
 
       - name: Run basic tests (Runs in ubuntu:${{ matrix.ubuntu_version }} derived image)


### PR DESCRIPTION
`$GITHUB_ENV` has no effect until the next step, so without this `echo $BOOTSTRAP_PIP_SPEC` is always empty