### PR TITLE
Update progress_page_favicon_url link

### DIFF
--- a/bootstrap/bootstrap.py
+++ b/bootstrap/bootstrap.py
@@ -47,7 +47,7 @@ import logging
 import shutil
 import urllib.request
 
-progress_page_favicon_url = "https://raw.githubusercontent.com/jupyterhub/jupyterhub/HEAD/share/jupyterhub/static/favicon.ico"
+progress_page_favicon_url = "https://raw.githubusercontent.com/jupyterhub/jupyterhub/main/share/jupyterhub/static/favicon.ico"
 progress_page_html = """
 <html>
 <head>


### PR DESCRIPTION
Using `HEAD` for https://raw.githubusercontent.com/ doesn't seem to be working and https://raw.githubusercontent.com/jupyterhub/jupyterhub/HEAD/share/jupyterhub/static/favicon.ico throws a 404

-<s>[ ] Add / update documentation</s>
-<s>[ ] Add tests<s>

 <!-- Read more about our code-review guidelines at https://the-littlest-jupyterhub.readthedocs.io/en/latest/contributing/code-review.html -->
