### PR TITLE
Add the ability to define conda channels in plugins

### DIFF
--- a/docs/contributing/plugins.rst
+++ b/docs/contributing/plugins.rst
@@ -114,6 +114,22 @@ environment from conda-forge.
             'iris',
             'dask',
         ]
+        
+By default packages are only installed from the ``conda-forge`` channel.
+If you need other channels, like ``bioconda`` or self-made channels,
+they can be added by using the ``tljh_extra_user_conda_channels`` hook.
+
+.. code-block:: python
+
+    from tljh.hooks import hookimpl
+
+    @hookimpl
+    def tljh_extra_user_conda_channels():
+        return [
+            'conda-forge',
+            'bioconda',
+            'fastai',
+        ]
 
 
 Publishing plugins

--- a/integration-tests/plugins/simplest/tljh_simplest.py
+++ b/integration-tests/plugins/simplest/tljh_simplest.py
@@ -8,6 +8,14 @@ from tljh.hooks import hookimpl
 def tljh_extra_user_conda_packages():
     return [
         "hypothesis",
+        "csvtk"
+    ]
+
+@hookimpl
+def tljh_extra_user_conda_channels():
+    return [
+        "conda-forge",
+        "bioconda"
     ]
 
 

--- a/integration-tests/test_simplest_plugin.py
+++ b/integration-tests/test_simplest_plugin.py
@@ -33,6 +33,7 @@ def test_conda_packages():
     Test extra user conda packages are installed
     """
     subprocess.check_call([f"{USER_ENV_PREFIX}/bin/python3", "-c", "import hypothesis"])
+    subprocess.check_call([f"{USER_ENV_PREFIX}/bin/csvtk", "cat", "--help"])
 
 
 def test_config_hook():

--- a/tests/test_conda.py
+++ b/tests/test_conda.py
@@ -43,6 +43,15 @@ def test_ensure_packages(prefix):
     # Throws an error if this fails
     subprocess.check_call([os.path.join(prefix, "bin", "python"), "-c", "import numpy"])
 
+    
+def test_ensure_channel_packages(prefix):
+    """
+    Test installing packages in conda environment
+    """
+    conda.ensure_conda_packages(prefix, ["csvtk"], channels=('conda-forge', 'bioconda'))
+    # Throws an error if this fails
+    subprocess.check_call([os.path.join(prefix, "bin", "csvtk"), "cat", "--help"])
+    
 
 def test_ensure_pip_packages(prefix):
     """

--- a/tljh/conda.py
+++ b/tljh/conda.py
@@ -90,9 +90,9 @@ def install_miniconda(installer_path, prefix):
     fix_permissions(prefix)
 
 
-def ensure_conda_packages(prefix, packages):
+def ensure_conda_packages(prefix, packages, channels=('conda-forge',)):
     """
-    Ensure packages (from conda-forge) are installed in the conda prefix.
+    Ensure packages (from channels) are installed in the conda prefix.
 
     Note that conda seem to update dependencies by default, so there is probably
     no need to have a update parameter exposed for this function.
@@ -103,16 +103,18 @@ def ensure_conda_packages(prefix, packages):
     # Explicitly do *not* capture stderr, since that's not always JSON!
     # Scripting conda is a PITA!
     # FIXME: raise different exception when using
+    
+    channel_cmd = '-c ' + ' -c '.join(channels)
+    
     raw_output = subprocess.check_output(
         conda_executable
         + [
             "install",
-            "-c",
-            "conda-forge",  # Make customizable if we ever need to
             "--json",
             "--prefix",
             abspath,
         ]
+        + channel_cmd.split()
         + packages
     ).decode()
     # `conda install` outputs JSON lines for fetch updates,

--- a/tljh/hooks.py
+++ b/tljh/hooks.py
@@ -16,6 +16,14 @@ def tljh_extra_user_conda_packages():
 
 
 @hookspec
+def tljh_extra_user_conda_channels():
+    """
+    Return a list of conda channels to be used during user environment installation.
+    """
+    pass
+
+
+@hookspec
 def tljh_extra_user_pip_packages():
     """
     Return list of extra pip packages to install in user environment.

--- a/tljh/installer.py
+++ b/tljh/installer.py
@@ -370,13 +370,16 @@ def run_plugin_actions(plugin_manager):
 
     # Install conda packages
     conda_packages = list(set(itertools.chain(*hook.tljh_extra_user_conda_packages())))
+    conda_channels = list(itertools.chain(*hook.tljh_extra_user_conda_channels()))
+    if len(conda_channels) == 0:
+        conda_channels = ('conda-forge',)
     if conda_packages:
         logger.info(
             "Installing {} user conda packages collected from plugins: {}".format(
                 len(conda_packages), " ".join(conda_packages)
             )
         )
-        conda.ensure_conda_packages(USER_ENV_PREFIX, conda_packages)
+        conda.ensure_conda_packages(USER_ENV_PREFIX, conda_packages, conda_channels=conda_channels)
 
     # Install pip packages
     user_pip_packages = list(set(itertools.chain(*hook.tljh_extra_user_pip_packages())))


### PR DESCRIPTION
- [x] Add / update documentation
- [x] Add tests

This PR addresses issue #828. It adds a `tljh_extra_user_conda_channels` hook to allow plugin developers to change the conda channels during user environment install. Adding an extra hook seems to be the most elegant solution as it allows install logic to be encapsulated in the plugin as opposed to requiring the end-user to add it during the install command.

I've added unit-tests, integration tests, and a note to the documentation.  If there are any stylistic changes you'd like, I'd be happy to adjust them.