### PR TITLE
ci: add dependabot for github actions and bump them now

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+# dependabot.yml reference: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+#
+# Notes:
+# - Status and logs from dependabot are provided at
+#   https://github.com/jupyterhub/the-littlest-jupyterhub/network/updates.
+# - YAML anchors are not supported here or in GitHub Workflows.
+#
+version: 2
+updates:
+  # Maintain dependencies in our GitHub Workflows
+  - package-ecosystem: github-actions
+    directory: "/" # This should be / rather than .github/workflows
+    schedule:
+      interval: weekly
+      time: "05:00"
+      timezone: "Etc/UTC"

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -95,8 +95,8 @@ jobs:
       matrix: ${{ fromJson(needs.decide-on-test-jobs-to-run.outputs.matrix) }}
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: "${{ matrix.python_version }}"
 

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -53,8 +53,8 @@ jobs:
             python_version: "3.10"
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: "${{ matrix.python_version }}"
 
@@ -74,7 +74,7 @@ jobs:
       #          completion. Make sure to update the key to bust the cache
       #          properly if you make a change that should influence it.
       - name: Load cached Python dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: /srv/venv/
           key: >-


### PR DESCRIPTION
- ci: add dependabot bumping of github actions
- ci: update github action versions

- [ ] Add / update documentation
- [ ] Add tests

 <!-- Read more about our code-review guidelines at https://the-littlest-jupyterhub.readthedocs.io/en/latest/contributing/code-review.html -->
