### PR TITLE
ci: fix deprecation of set-output in github workflows

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -55,7 +55,7 @@ jobs:
           echo "matrix=$matrix_post_filter" >> $GITHUB_OUTPUT
 
           echo "The subsequent job's matrix are:"
-          echo $matrix_post_filter | jq '.'
+          echo $matrix_post_filter | jq -C '.'
         env:
           matrix_include_pre_filter: |
             - name: "Int. tests: Ubuntu 18.04, Py 3.6"

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -50,9 +50,9 @@ jobs:
           matrix_post_filter=$(
             echo "$matrix_include_pre_filter" \
               | yq e --output-format=json '.' - \
-              | jq '{"include": map( . | select(.dont_run_on_ref != "${{ github.ref }}" ))}'
+              | jq -c '{"include": map( . | select(.dont_run_on_ref != "${{ github.ref }}" ))}'
           )
-          echo ::set-output name=matrix::$(echo "$matrix_post_filter")
+          echo "matrix=$matrix_post_filter" >> $GITHUB_OUTPUT
 
           echo "The subsequent job's matrix are:"
           echo $matrix_post_filter | jq '.'


### PR DESCRIPTION
- Addresses https://github.com/jupyterhub/team-compass/issues/579 for this repo.

I confirmed that the test failures in this PR are unrelated as they [occurr in the main branch](https://github.com/jupyterhub/the-littlest-jupyterhub/actions/runs/3461480274) as well now. See https://github.com/jupyterhub/the-littlest-jupyterhub/issues/830 about that.