### PR TITLE
Ensure SQLAlchemy 1.x used for hub

### DIFF
--- a/tljh/installer.py
+++ b/tljh/installer.py
@@ -121,6 +121,7 @@ def ensure_jupyterhub_package(prefix):
     conda.ensure_pip_packages(
         prefix,
         [
+            "SQLAlchemy<2.0.0",
             "jupyterhub==1.*",
             "jupyterhub-systemdspawner==0.16.*",
             "jupyterhub-firstuseauthenticator==1.*",

--- a/tljh/requirements-base.txt
+++ b/tljh/requirements-base.txt
@@ -5,6 +5,8 @@
 #          the requirements-txt-fixer pre-commit hook that sorted them and made
 #          our integration tests fail.
 #
+# For JupyterHub 1.x SQLAlchemy below 2.0.0
+SQLAlchemy<2.0.0
 # JupyterHub + notebook package are base requirements for user environment
 jupyterhub==1.*
 notebook==6.*


### PR DESCRIPTION
Fixes #846

- [ ] Add / update documentation
- [ ] Add tests

 <!-- Read more about our code-review guidelines at https://the-littlest-jupyterhub.readthedocs.io/en/latest/contributing/code-review.html -->
 
 Tested by rerunning installer in dev setup

```
source /opt/tljh/hub/bin/activate
cd /srv/src
python3 -m tljh.installer
```