### PR TITLE
Traefik v2, TraefikProxy v1

### DIFF
--- a/integration-tests/conftest.py
+++ b/integration-tests/conftest.py
@@ -25,5 +25,5 @@ def preserve_config(request):
                 f.write(save_config)
         elif os.path.exists(CONFIG_FILE):
             os.remove(CONFIG_FILE)
-        reload_component("hub")
         reload_component("proxy")
+        reload_component("hub")

--- a/integration-tests/test_bootstrap.py
+++ b/integration-tests/test_bootstrap.py
@@ -4,6 +4,7 @@ Test running bootstrap script in different circumstances
 import concurrent.futures
 import os
 import subprocess
+import sys
 import time
 
 BASE_IMAGE = os.getenv("BASE_IMAGE", "ubuntu:20.04")
@@ -162,8 +163,13 @@ def verify_progress_page(expected_status_code, timeout):
             if b"HTTP/1.0 200 OK" in resp:
                 progress_page_status = True
                 break
-        except Exception:
-            time.sleep(2)
+            else:
+                print(
+                    f"Unexpected progress page response: {resp[:100]}", file=sys.stderr
+                )
+        except Exception as e:
+            print(f"Error getting progress page: {e}", file=sys.stderr)
+            time.sleep(1)
             continue
 
     return progress_page_status

--- a/integration-tests/test_bootstrap.py
+++ b/integration-tests/test_bootstrap.py
@@ -185,7 +185,7 @@ def test_progress_page():
         )
 
         # Check if progress page started
-        started = verify_progress_page(expected_status_code=200, timeout=120)
+        started = verify_progress_page(expected_status_code=200, timeout=180)
         assert started
 
         # This will fail start tljh but should successfully get to the point

--- a/integration-tests/test_proxy.py
+++ b/integration-tests/test_proxy.py
@@ -19,9 +19,7 @@ from tljh.config import (
 
 
 def send_request(url, max_sleep, validate_cert=True, username=None, password=None):
-    resp = None
     for i in range(max_sleep):
-        time.sleep(i)
         try:
             req = HTTPRequest(
                 url,
@@ -32,12 +30,12 @@ def send_request(url, max_sleep, validate_cert=True, username=None, password=Non
                 follow_redirects=True,
                 max_redirects=15,
             )
-            resp = HTTPClient().fetch(req)
-            break
+            return HTTPClient().fetch(req)
         except Exception as e:
+            if i + 1 == max_sleep:
+                raise
             print(e)
-
-    return resp
+            time.sleep(i)
 
 
 def test_manual_https(preserve_config):
@@ -104,37 +102,51 @@ def test_extra_traefik_config():
     os.makedirs(dynamic_config_dir, exist_ok=True)
 
     extra_static_config = {
-        "entryPoints": {"no_auth_api": {"address": "127.0.0.1:9999"}},
-        "api": {"dashboard": True, "entrypoint": "no_auth_api"},
+        "entryPoints": {"alsoHub": {"address": "127.0.0.1:9999"}},
     }
 
     extra_dynamic_config = {
-        "frontends": {
-            "test": {
-                "backend": "test",
-                "routes": {
-                    "rule1": {"rule": "PathPrefixStrip: /the/hub/runs/here/too"}
+        "http": {
+            "middlewares": {
+                "testHubStripPrefix": {
+                    "stripPrefix": {"prefixes": ["/the/hub/runs/here/too"]}
+                }
+            },
+            "routers": {
+                "test1": {
+                    "rule": "PathPrefix(`/hub`)",
+                    "entryPoints": ["alsoHub"],
+                    "service": "test",
                 },
-            }
-        },
-        "backends": {
-            # redirect to hub
-            "test": {"servers": {"server1": {"url": "http://127.0.0.1:15001"}}}
+                "test2": {
+                    "rule": "PathPrefix(`/the/hub/runs/here/too`)",
+                    "middlewares": ["testHubStripPrefix"],
+                    "entryPoints": ["http"],
+                    "service": "test",
+                },
+            },
+            "services": {
+                "test": {
+                    "loadBalancer": {
+                        # forward requests to the hub
+                        "servers": [{"url": "http://127.0.0.1:15001"}]
+                    }
+                }
+            },
         },
     }
 
     success = False
     for i in range(5):
-        time.sleep(i)
         try:
             with pytest.raises(HTTPClientError, match="HTTP 401: Unauthorized"):
-                # The default dashboard entrypoint requires authentication, so it should fail
-                req = HTTPRequest("http://127.0.0.1:8099/dashboard/", method="GET")
-                HTTPClient().fetch(req)
+                # The default api entrypoint requires authentication, so it should fail
+                HTTPClient().fetch("http://localhost:8099/api")
             success = True
             break
-        except Exception:
-            pass
+        except Exception as e:
+            print(e)
+            time.sleep(i)
 
     assert success == True
 
@@ -153,8 +165,9 @@ def test_extra_traefik_config():
     # load the extra config
     reload_component("proxy")
 
+    # check hub page
     # the new dashboard entrypoint shouldn't require authentication anymore
-    resp = send_request(url="http://127.0.0.1:9999/dashboard/", max_sleep=5)
+    resp = send_request(url="http://127.0.0.1:9999/hub/login", max_sleep=5)
     assert resp.code == 200
 
     # test extra dynamic config

--- a/setup.py
+++ b/setup.py
@@ -14,11 +14,10 @@ setup(
         "ruamel.yaml==0.17.*",
         "jinja2",
         "pluggy==1.*",
-        "passlib",
         "backoff",
         "requests",
         "bcrypt",
-        "jupyterhub-traefik-proxy==0.3.*",
+        "jupyterhub-traefik-proxy==1.0.0b3",
     ],
     entry_points={
         "console_scripts": [

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
         "backoff",
         "requests",
         "bcrypt",
-        "jupyterhub-traefik-proxy==1.0.0b3",
+        "jupyterhub-traefik-proxy==1.*",
     ],
     entry_points={
         "console_scripts": [

--- a/tests/test_configurer.py
+++ b/tests/test_configurer.py
@@ -156,8 +156,8 @@ def test_traefik_api_default():
     """
     c = apply_mock_config({})
 
-    assert c.TraefikTomlProxy.traefik_api_username == "api_admin"
-    assert len(c.TraefikTomlProxy.traefik_api_password) == 0
+    assert c.TraefikProxy.traefik_api_username == "api_admin"
+    assert len(c.TraefikProxy.traefik_api_password) == 0
 
 
 def test_set_traefik_api():
@@ -167,8 +167,8 @@ def test_set_traefik_api():
     c = apply_mock_config(
         {"traefik_api": {"username": "some_user", "password": "1234"}}
     )
-    assert c.TraefikTomlProxy.traefik_api_username == "some_user"
-    assert c.TraefikTomlProxy.traefik_api_password == "1234"
+    assert c.TraefikProxy.traefik_api_username == "some_user"
+    assert c.TraefikProxy.traefik_api_password == "1234"
 
 
 def test_cull_service_default():
@@ -268,7 +268,7 @@ def test_load_secrets(tljh_dir):
     tljh_config = configurer.load_config()
     assert tljh_config["traefik_api"]["password"] == "traefik-password"
     c = apply_mock_config(tljh_config)
-    assert c.TraefikTomlProxy.traefik_api_password == "traefik-password"
+    assert c.TraefikProxy.traefik_api_password == "traefik-password"
 
 
 def test_auth_native():

--- a/tests/test_traefik.py
+++ b/tests/test_traefik.py
@@ -101,7 +101,19 @@ def test_letsencrypt_config(tljh_dir):
     dynamic_config = _read_dynamic_config(state_dir)
 
     assert dynamic_config["tls"] == {
-        "options": {"default": {"minVersion": "VersionTLS12"}},
+        "options": {
+            "default": {
+                "minVersion": "VersionTLS12",
+                "cipherSuites": [
+                    "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+                    "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+                    "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+                    "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+                    "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305",
+                    "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
+                ],
+            }
+        },
         "stores": {
             "default": {
                 "defaultGeneratedCert": {
@@ -166,7 +178,19 @@ def test_manual_ssl_config(tljh_dir):
     assert "tls" in dynamic_config
 
     assert dynamic_config["tls"] == {
-        "options": {"default": {"minVersion": "VersionTLS12"}},
+        "options": {
+            "default": {
+                "minVersion": "VersionTLS12",
+                "cipherSuites": [
+                    "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+                    "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+                    "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+                    "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+                    "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305",
+                    "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
+                ],
+            },
+        },
         "stores": {
             "default": {
                 "defaultCertificate": {

--- a/tests/test_traefik.py
+++ b/tests/test_traefik.py
@@ -114,13 +114,13 @@ def test_letsencrypt_config(tljh_dir):
             }
         },
     }
-    assert "certificateResolvers" in cfg
-    assert "letsencrypt" in cfg["certificateResolvers"]
+    assert "certificatesResolvers" in cfg
+    assert "letsencrypt" in cfg["certificatesResolvers"]
 
-    assert cfg["certificateResolvers"]["letsencrypt"]["acme"] == {
+    assert cfg["certificatesResolvers"]["letsencrypt"]["acme"] == {
         "email": "fake@jupyter.org",
         "storage": "acme.json",
-        "httpChallenge": {"entryPoint": "http"},
+        "tlsChallenge": {},
     }
 
 

--- a/tljh/config.py
+++ b/tljh/config.py
@@ -249,8 +249,11 @@ def check_hub_ready():
         r = requests.get(
             "http://127.0.0.1:%d%s/hub/api" % (http_port, base_url), verify=False
         )
+        if r.status_code != 200:
+            print(f"Hub not ready: (HTTP status {r.status_code})")
         return r.status_code == 200
-    except:
+    except Exception as e:
+        print(f"Hub not ready: {e}")
         return False
 
 

--- a/tljh/configurer.py
+++ b/tljh/configurer.py
@@ -40,6 +40,7 @@ default = {
         "letsencrypt": {
             "email": "",
             "domains": [],
+            "staging": False,
         },
     },
     "traefik_api": {

--- a/tljh/configurer.py
+++ b/tljh/configurer.py
@@ -239,8 +239,13 @@ def update_traefik_api(c, config):
     """
     Set traefik api endpoint credentials
     """
-    c.TraefikTomlProxy.traefik_api_username = config["traefik_api"]["username"]
-    c.TraefikTomlProxy.traefik_api_password = config["traefik_api"]["password"]
+    c.TraefikProxy.traefik_api_username = config["traefik_api"]["username"]
+    c.TraefikProxy.traefik_api_password = config["traefik_api"]["password"]
+    https = config["https"]
+    if https["enabled"]:
+        c.TraefikProxy.traefik_entrypoint = "https"
+    else:
+        c.TraefikProxy.traefik_entrypoint = "http"
 
 
 def set_cull_idle_service(config):

--- a/tljh/jupyterhub_config.py
+++ b/tljh/jupyterhub_config.py
@@ -5,13 +5,12 @@ JupyterHub config for the littlest jupyterhub.
 import os
 from glob import glob
 
-from jupyterhub_traefik_proxy import TraefikTomlProxy
-
 from tljh import configurer
 from tljh.config import CONFIG_DIR, INSTALL_PREFIX, USER_ENV_PREFIX
 from tljh.user_creating_spawner import UserCreatingSpawner
 from tljh.utils import get_plugin_manager
 
+c = get_config()  # noqa
 c.JupyterHub.spawner_class = UserCreatingSpawner
 
 # leave users running when the Hub restarts
@@ -20,11 +19,11 @@ c.JupyterHub.cleanup_servers = False
 # Use a high port so users can try this on machines with a JupyterHub already present
 c.JupyterHub.hub_port = 15001
 
-c.TraefikTomlProxy.should_start = False
+c.TraefikProxy.should_start = False
 
 dynamic_conf_file_path = os.path.join(INSTALL_PREFIX, "state", "rules", "rules.toml")
-c.TraefikTomlProxy.toml_dynamic_config_file = dynamic_conf_file_path
-c.JupyterHub.proxy_class = TraefikTomlProxy
+c.TraefikFileProviderProxy.dynamic_config_file = dynamic_conf_file_path
+c.JupyterHub.proxy_class = "traefik_file"
 
 c.SystemdSpawner.extra_paths = [os.path.join(USER_ENV_PREFIX, "bin")]
 c.SystemdSpawner.default_shell = "/bin/bash"

--- a/tljh/traefik-dynamic.toml.tpl
+++ b/tljh/traefik-dynamic.toml.tpl
@@ -1,0 +1,25 @@
+# traefik.toml dynamic config (mostly TLS)
+# dynamic config in the static config file will be ignored
+{% if https['enabled'] %}
+[tls]
+  [tls.options.default]
+  minVersion = "VersionTLS12"
+
+  {% if https['tls']['cert'] %}
+  [tls.stores.default.defaultCertificate]
+    certFile = "{{ https['tls']['cert'] }}"
+    keyFile = "{{ https['tls']['key'] }}"
+  {% endif %}
+
+  {% if https['letsencrypt']['email'] and https['letsencrypt']['domains'] %}
+  [tls.stores.default.defaultGeneratedCert]
+  resolver = "letsencrypt"
+    [tls.stores.default.defaultGeneratedCert.domain]
+    main = "{{ https['letsencrypt']['domains'][0] }}"
+    sans = [
+      {% for domain in https['letsencrypt']['domains'][1:] %}
+      "{{ domain }}",
+      {% endfor %}
+    ]
+  {% endif %}
+{% endif %}

--- a/tljh/traefik-dynamic.toml.tpl
+++ b/tljh/traefik-dynamic.toml.tpl
@@ -1,6 +1,6 @@
 # traefik.toml dynamic config (mostly TLS)
 # dynamic config in the static config file will be ignored
-{% if https['enabled'] %}
+{%- if https['enabled'] %}
 [tls]
   [tls.options.default]
   minVersion = "VersionTLS12"
@@ -12,13 +12,13 @@
     "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305",
     "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
   ]
-  {% if https['tls']['cert'] -%}
+  {%- if https['tls']['cert'] %}
   [tls.stores.default.defaultCertificate]
     certFile = "{{ https['tls']['cert'] }}"
     keyFile = "{{ https['tls']['key'] }}"
   {%- endif %}
 
-  {% if https['letsencrypt']['email'] and https['letsencrypt']['domains'] -%}
+  {%- if https['letsencrypt']['email'] and https['letsencrypt']['domains'] %}
   [tls.stores.default.defaultGeneratedCert]
   resolver = "letsencrypt"
     [tls.stores.default.defaultGeneratedCert.domain]
@@ -29,4 +29,4 @@
       {%- endfor %}
     ]
   {%- endif %}
-{% endif %}
+{%- endif %}

--- a/tljh/traefik-dynamic.toml.tpl
+++ b/tljh/traefik-dynamic.toml.tpl
@@ -5,21 +5,21 @@
   [tls.options.default]
   minVersion = "VersionTLS12"
 
-  {% if https['tls']['cert'] %}
+  {% if https['tls']['cert'] -%}
   [tls.stores.default.defaultCertificate]
     certFile = "{{ https['tls']['cert'] }}"
     keyFile = "{{ https['tls']['key'] }}"
-  {% endif %}
+  {%- endif %}
 
-  {% if https['letsencrypt']['email'] and https['letsencrypt']['domains'] %}
+  {% if https['letsencrypt']['email'] and https['letsencrypt']['domains'] -%}
   [tls.stores.default.defaultGeneratedCert]
   resolver = "letsencrypt"
     [tls.stores.default.defaultGeneratedCert.domain]
     main = "{{ https['letsencrypt']['domains'][0] }}"
     sans = [
-      {% for domain in https['letsencrypt']['domains'][1:] %}
+      {% for domain in https['letsencrypt']['domains'][1:] -%}
       "{{ domain }}",
-      {% endfor %}
+      {%- endfor %}
     ]
-  {% endif %}
+  {%- endif %}
 {% endif %}

--- a/tljh/traefik-dynamic.toml.tpl
+++ b/tljh/traefik-dynamic.toml.tpl
@@ -4,7 +4,14 @@
 [tls]
   [tls.options.default]
   minVersion = "VersionTLS12"
-
+  cipherSuites = [
+    "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+    "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+    "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+    "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+    "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305",
+    "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
+  ]
   {% if https['tls']['cert'] -%}
   [tls.stores.default.defaultCertificate]
     certFile = "{{ https['tls']['cert'] }}"

--- a/tljh/traefik.py
+++ b/tljh/traefik.py
@@ -27,7 +27,8 @@ elif machine == "x86_64":
 else:
     plat = None
 
-traefik_version = "2.9.9"
+# Traefik releases: https://github.com/traefik/traefik/releases
+traefik_version = "2.10.1"
 
 # record sha256 hashes for supported platforms here
 checksums = {

--- a/tljh/traefik.py
+++ b/tljh/traefik.py
@@ -31,9 +31,10 @@ else:
 traefik_version = "2.10.1"
 
 # record sha256 hashes for supported platforms here
+# checksums are published in the checksums.txt of each release
 checksums = {
-    "linux_amd64": "141db1434ae76890915486a4bc5ecf3dbafc8ece78984ce1a8db07737c42db88",
-    "linux_arm64": "0a65ead411307669916ba629fa13f698acda0b2c5387abe0309b43e168e4e57f",
+    "linux_amd64": "8d9bce0e6a5bf40b5399dbb1d5e3e5c57b9f9f04dd56a2dd57cb0713130bc824",
+    "linux_arm64": "260a574105e44901f8c9c562055936d81fbd9c96a21daaa575502dc69bfe390a",
 }
 
 _tljh_path = Path(__file__).parent.resolve()
@@ -103,7 +104,7 @@ def ensure_traefik_binary(prefix):
             os.remove(traefik_bin)
 
     traefik_url = (
-        "https://github.com/containous/traefik/releases"
+        "https://github.com/traefik/traefik/releases"
         f"/download/v{traefik_version}/traefik_v{traefik_version}_{plat}.tar.gz"
     )
 

--- a/tljh/traefik.toml.tpl
+++ b/tljh/traefik.toml.tpl
@@ -23,35 +23,37 @@ X-Xsrftoken = "redact"
 [entryPoints]
   [entryPoints.http]
   address = ":{{ http['port'] }}"
+
   [entryPoints.http.transport.respondingTimeouts]
   idleTimeout = "10m"
 
-  {% if https['enabled'] %}
+  {%- if https['enabled'] %}
   [entryPoints.http.http.redirections.entryPoint]
   to = "https"
   scheme = "https"
 
   [entryPoints.https]
   address = ":{{ https['port'] }}"
+
   [entryPoints.https.http.tls]
   options = "default"
 
   [entryPoints.https.transport.respondingTimeouts]
   idleTimeout = "10m"
-  {% endif %}
+  {%- endif %}
 
   [entryPoints.auth_api]
   address = "localhost:{{ traefik_api['port'] }}"
 
-{% if https['enabled'] and https['letsencrypt']['email'] and https['letsencrypt']['domains'] %}
+{%- if https['enabled'] and https['letsencrypt']['email'] and https['letsencrypt']['domains'] %}
 [certificatesResolvers.letsencrypt.acme]
 email = "{{ https['letsencrypt']['email'] }}"
 storage = "acme.json"
-{% if https['letsencrypt']['staging'] -%}
+{%- if https['letsencrypt']['staging'] %}
 caServer = "https://acme-staging-v02.api.letsencrypt.org/directory"
 {%- endif %}
 [certificatesResolvers.letsencrypt.acme.tlsChallenge]
-{% endif %}
+{%- endif %}
 
 [providers]
 providersThrottleDuration = "0s"

--- a/tljh/traefik.toml.tpl
+++ b/tljh/traefik.toml.tpl
@@ -1,74 +1,59 @@
-# traefik.toml file template
-{% if https['enabled'] %}
-defaultEntryPoints = ["http", "https"]
-{% else %}
-defaultEntryPoints = ["http"]
-{% endif %}
+# traefik.toml static config file template
+# dynamic config (e.g. TLS) goes in traefik-dynamic.toml.tpl
 
-logLevel = "INFO"
+# enable API
+[api]
+
+[log]
+level = "INFO"
+
 # log errors, which could be proxy errors
 [accessLog]
 format = "json"
+
 [accessLog.filters]
 statusCodes = ["500-999"]
 
-[accessLog.fields.headers]
 [accessLog.fields.headers.names]
 Authorization = "redact"
 Cookie = "redact"
 Set-Cookie = "redact"
 X-Xsrftoken = "redact"
 
-[respondingTimeouts]
-idleTimeout = "10m0s"
-
 [entryPoints]
   [entryPoints.http]
-  address = ":{{http['port']}}"
-  {% if https['enabled'] %}
-    [entryPoints.http.redirect]
-    entryPoint = "https"
-  {% endif %}
+  address = ":{{ http['port'] }}"
+  [entryPoints.http.transport.respondingTimeouts]
+  idleTimeout = "10m"
 
   {% if https['enabled'] %}
+  [entryPoints.http.http.redirections.entryPoint]
+  to = "https"
+  scheme = "https"
+
   [entryPoints.https]
-  address = ":{{https['port']}}"
-  [entryPoints.https.tls]
-  minVersion = "VersionTLS12"
-  {% if https['tls']['cert'] %}
-    [[entryPoints.https.tls.certificates]]
-      certFile = "{{https['tls']['cert']}}"
-      keyFile = "{{https['tls']['key']}}"
+  address = ":{{ https['port'] }}"
+  [entryPoints.https.http.tls]
+  options = "default"
+
+  [entryPoints.https.transport.respondingTimeouts]
+  idleTimeout = "10m"
   {% endif %}
-  {% endif %}
+
   [entryPoints.auth_api]
-  address = "127.0.0.1:{{traefik_api['port']}}"
-  [entryPoints.auth_api.whiteList]
-  sourceRange = ['{{traefik_api['ip']}}']
-  [entryPoints.auth_api.auth.basic]
-  users = ['{{ traefik_api['basic_auth'] }}']
+  address = "localhost:{{ traefik_api['port'] }}"
 
-[wss]
-protocol = "http"
-
-[api]
-dashboard = true
-entrypoint = "auth_api"
-
-{% if https['enabled'] and https['letsencrypt']['email'] %}
-[acme]
-email = "{{https['letsencrypt']['email']}}"
+{% if https['enabled'] and https['letsencrypt']['email'] and https['letsencrypt']['domains'] %}
+[certificateResolvers.letsencrypt.acme]
+email = "{{ https['letsencrypt']['email'] }}"
 storage = "acme.json"
-entryPoint = "https"
-  [acme.httpChallenge]
-  entryPoint = "http"
-
-{% for domain in https['letsencrypt']['domains'] %}
-[[acme.domains]]
-  main = "{{domain}}"
-{% endfor %}
+[certificateResolvers.letsencrypt.acme.httpChallenge]
+entryPoint = "http"
 {% endif %}
 
-[file]
-directory = "rules"
+[providers]
+providersThrottleDuration = "0s"
+
+[providers.file]
+directory = "{{ traefik_dynamic_config_dir }}"
 watch = true

--- a/tljh/traefik.toml.tpl
+++ b/tljh/traefik.toml.tpl
@@ -47,6 +47,9 @@ X-Xsrftoken = "redact"
 [certificatesResolvers.letsencrypt.acme]
 email = "{{ https['letsencrypt']['email'] }}"
 storage = "acme.json"
+{% if https['letsencrypt']['staging'] -%}
+caServer = "https://acme-staging-v02.api.letsencrypt.org/directory"
+{%- endif %}
 [certificatesResolvers.letsencrypt.acme.tlsChallenge]
 {% endif %}
 

--- a/tljh/traefik.toml.tpl
+++ b/tljh/traefik.toml.tpl
@@ -44,11 +44,10 @@ X-Xsrftoken = "redact"
   address = "localhost:{{ traefik_api['port'] }}"
 
 {% if https['enabled'] and https['letsencrypt']['email'] and https['letsencrypt']['domains'] %}
-[certificateResolvers.letsencrypt.acme]
+[certificatesResolvers.letsencrypt.acme]
 email = "{{ https['letsencrypt']['email'] }}"
 storage = "acme.json"
-[certificateResolvers.letsencrypt.acme.httpChallenge]
-entryPoint = "http"
+[certificatesResolvers.letsencrypt.acme.tlsChallenge]
 {% endif %}
 
 [providers]


### PR DESCRIPTION
Updates:

- jupyterhub-traefik-proxy to 1.0
- traefik to 2.10

traefik v2 totally changed their config file format, so several config options needed to move around, but ultimately the behavior is unchanged. jupyterhub-traefik-proxy 1.0 is required to use traefik v2 due to the config and API changes. Some configuration is no longer required as jupyterhub-traefik-proxy writes initial dynamic config (api route, auth) during its startup, instead of requiring to duplicate that info to the traefik config file.

This is a breaking change for the rare cases where users configured traefik or TraefikProxy directly, since both are major changes, but for most users the change should not be noticed (🤞) except as a performance boost when there are many users.

closes #513