### PR TITLE
avoid registering duplicate log handlers

### DIFF
--- a/tljh/log.py
+++ b/tljh/log.py
@@ -9,6 +9,13 @@ def init_logging():
     """Setup default tljh logger"""
     logger = logging.getLogger("tljh")
     os.makedirs(INSTALL_PREFIX, exist_ok=True)
+
+    # check if any log handlers are already registered
+    # don't reconfigure logs if handlers are already configured
+    # e.g. happens in pytest, which hooks up log handlers for reporting
+    # or if this function is called twice
+    if logger.hasHandlers():
+        return
     file_logger = logging.FileHandler(os.path.join(INSTALL_PREFIX, "installer.log"))
     file_logger.setFormatter(logging.Formatter("%(asctime)s %(message)s"))
     logger.addHandler(file_logger)


### PR DESCRIPTION
init_logging is called many times in test_config, which has been registering numerous duplicate log handlers, attached to stderr that's closed between tests
