### PR TITLE
breaking, maint: remove deprecated nteract-on-jupyter

### DIFF
--- a/docs/contributing/docs.md
+++ b/docs/contributing/docs.md
@@ -150,7 +150,7 @@ documentation:
   capitalized except when used in code / the commandline.
 - **Python** -- when referring to the language, capitalize Python.
 - **Notebook Interface** -- generic term for referring to JupyterLab,
-  nteract, classic notebook & other user interfaces for accessing
+  classic notebook & other user interfaces for accessing.
 
 ## Guidelines for markdown files
 

--- a/docs/contributing/packages.md
+++ b/docs/contributing/packages.md
@@ -16,7 +16,7 @@ TLJH sets up two python environments during installation.
    primarily since conda does not support ARM CPUs and we'd like to support the
    RaspberryPI someday. Admins generally do not install custom packages
    in this environment.
-2. **User Environment**. Jupyter Notebook, JupyterLab, nteract, kernels,
+2. **User Environment**. Jupyter Notebook, JupyterLab, kernels,
    and packages the users wanna use (such as numpy, scipy, etc) are installed
    here. A [conda](https://conda.io) environment is used here, since
    a lot of scientific packages are available from Conda. `pip` is still

--- a/docs/topic/tljh-config.md
+++ b/docs/topic/tljh-config.md
@@ -138,8 +138,8 @@ sudo tljh-config reload proxy
 
 ### User Environment
 
-`user_environment.default_app` Set default application users are
-launched into. Currently this can only be set to: `jupyterlab`
+`user_environment.default_app` Set default application users are launched into.
+Currently this can only be set to: `classic` and `jupyterlab`.
 
 ```bash
 sudo tljh-config set user_environment.default_app jupyterlab

--- a/integration-tests/test_extensions.py
+++ b/integration-tests/test_extensions.py
@@ -14,7 +14,6 @@ def test_serverextensions():
     extensions = [
         "jupyterlab 3.",
         "nbgitpuller 1.",
-        "nteract_on_jupyter 2.1.",
         "jupyter_resource_usage",
     ]
 

--- a/tests/test_configurer.py
+++ b/tests/test_configurer.py
@@ -69,14 +69,6 @@ def test_app_jupyterlab():
     assert c.Spawner.default_url == "/lab"
 
 
-def test_app_nteract():
-    """
-    Test setting nteract as default application
-    """
-    c = apply_mock_config({"user_environment": {"default_app": "nteract"}})
-    assert c.Spawner.default_url == "/nteract"
-
-
 def test_auth_default():
     """
     Test default authentication settings with no overrides

--- a/tljh/configurer.py
+++ b/tljh/configurer.py
@@ -228,8 +228,6 @@ def update_user_environment(c, config):
     # Set default application users are launched into
     if user_env["default_app"] == "jupyterlab":
         c.Spawner.default_url = "/lab"
-    elif user_env["default_app"] == "nteract":
-        c.Spawner.default_url = "/nteract"
 
 
 def update_user_account_config(c, config):

--- a/tljh/requirements-base.txt
+++ b/tljh/requirements-base.txt
@@ -10,7 +10,6 @@ jupyterhub==3.*
 notebook==6.*
 # Install additional notebook frontends!
 jupyterlab==3.*
-nteract-on-jupyter==2.*
 # nbgitpuller for easily pulling in Git repositories
 nbgitpuller==1.*
 # jupyter-resource-usage to show people how much RAM they are using


### PR DESCRIPTION
As a followup to https://github.com/jupyterhub/the-littlest-jupyterhub/pull/842/files#r1146062727 in where we concluded that nteract-on-jupyter was deprecated (https://github.com/nteract/nteract/issues/5554#issuecomment-852434391).

- [x] Add / update documentation
- [x] Add tests (Removed test)