### PR TITLE
added `remove_named_servers` setting for jupyterhub-idle-culler

### DIFF
--- a/docs/topic/idle-culler.md
+++ b/docs/topic/idle-culler.md
@@ -40,6 +40,12 @@ the users will not be culled alongside their notebooks and will continue to exis
 services.cull.users = False
 ```
 
+If named servers are in use, they are not removed after being culled.
+
+```python
+services.cull.remove_named_servers = False
+```
+
 ## Configuring the idle culler
 
 The available configuration options are:
@@ -73,6 +79,16 @@ The maximum age can be configured using:
 
 ```bash
 sudo tljh-config set services.cull.max_age <server-max-age>
+sudo tljh-config reload
+```
+
+### Remove Named Servers
+
+Remove named servers after they are shutdown. Only applies if named servers are
+enabled on the hub installation:
+
+```bash
+sudo tljh-config set services.cull.remove_named_servers True
 sudo tljh-config reload
 ```
 

--- a/tests/test_configurer.py
+++ b/tests/test_configurer.py
@@ -193,33 +193,6 @@ def test_cull_service_default():
         }
     ]
 
-def test_cull_service_named():
-    """
-    Test default cull service settings with named server removal
-    """
-    c = apply_mock_config(
-        {"services": {"cull": {"every": 10, "remove_named_servers": True, "max_age": 60}}}
-    )
-
-    cull_cmd = [
-        sys.executable,
-        "-m",
-        "jupyterhub_idle_culler",
-        "--timeout=600",
-        "--cull-every=10",
-        "--concurrency=5",
-        "--max-age=60",
-        "--remove-named-servers",
-    ]
-    assert c.JupyterHub.services == [
-        {
-            "name": "cull-idle",
-            "admin": True,
-            "command": cull_cmd,
-        }
-    ]
-
-
 def test_set_cull_service():
     """
     Test setting cull service options
@@ -245,6 +218,32 @@ def test_set_cull_service():
         }
     ]
 
+def test_cull_service_named():
+    """
+    Test default cull service settings with named server removal
+    """
+    c = apply_mock_config(
+        {"services": {"cull": {"every": 10, "cull_users": True, "remove_named_servers": True, "max_age": 60}}}
+    )
+
+    cull_cmd = [
+        sys.executable,
+        "-m",
+        "jupyterhub_idle_culler",
+        "--timeout=600",
+        "--cull-every=10",
+        "--concurrency=5",
+        "--max-age=60",
+        "--cull-users",
+        "--remove-named-servers",
+    ]
+    assert c.JupyterHub.services == [
+        {
+            "name": "cull-idle",
+            "admin": True,
+            "command": cull_cmd,
+        }
+    ]
 
 def test_load_secrets(tljh_dir):
     """

--- a/tests/test_configurer.py
+++ b/tests/test_configurer.py
@@ -193,6 +193,7 @@ def test_cull_service_default():
         }
     ]
 
+
 def test_set_cull_service():
     """
     Test setting cull service options
@@ -218,12 +219,22 @@ def test_set_cull_service():
         }
     ]
 
+
 def test_cull_service_named():
     """
     Test default cull service settings with named server removal
     """
     c = apply_mock_config(
-        {"services": {"cull": {"every": 10, "cull_users": True, "remove_named_servers": True, "max_age": 60}}}
+        {
+            "services": {
+                "cull": {
+                    "every": 10,
+                    "cull_users": True,
+                    "remove_named_servers": True,
+                    "max_age": 60,
+                }
+            }
+        }
     )
 
     cull_cmd = [
@@ -244,6 +255,7 @@ def test_cull_service_named():
             "command": cull_cmd,
         }
     ]
+
 
 def test_load_secrets(tljh_dir):
     """

--- a/tests/test_configurer.py
+++ b/tests/test_configurer.py
@@ -193,6 +193,32 @@ def test_cull_service_default():
         }
     ]
 
+def test_cull_service_named():
+    """
+    Test default cull service settings with named server removal
+    """
+    c = apply_mock_config(
+        {"services": {"cull": {"every": 10, "remove_named_servers": True, "max_age": 60}}}
+    )
+
+    cull_cmd = [
+        sys.executable,
+        "-m",
+        "jupyterhub_idle_culler",
+        "--timeout=600",
+        "--cull-every=10",
+        "--concurrency=5",
+        "--max-age=60",
+        "--remove-named-servers",
+    ]
+    assert c.JupyterHub.services == [
+        {
+            "name": "cull-idle",
+            "admin": True,
+            "command": cull_cmd,
+        }
+    ]
+
 
 def test_set_cull_service():
     """

--- a/tljh/configurer.py
+++ b/tljh/configurer.py
@@ -59,7 +59,7 @@ default = {
             "concurrency": 5,
             "users": False,
             "max_age": 0,
-            "remove_named_servers": False
+            "remove_named_servers": False,
         },
         "configurator": {"enabled": False},
     },

--- a/tljh/configurer.py
+++ b/tljh/configurer.py
@@ -59,6 +59,7 @@ default = {
             "concurrency": 5,
             "users": False,
             "max_age": 0,
+            "remove_named_servers": False
         },
         "configurator": {"enabled": False},
     },
@@ -256,6 +257,8 @@ def set_cull_idle_service(config):
     cull_cmd += ["--max-age=%d" % cull_config["max_age"]]
     if cull_config["users"]:
         cull_cmd += ["--cull-users"]
+    if cull_config["remove_named_servers"]:
+        cull_cmd += ["--remove-named-servers"]
 
     cull_service = {
         "name": "cull-idle",


### PR DESCRIPTION
This is a duplicate of #855 by @stevejpurves that has been manually rebased to handle conflicts following from rST to MyST. I had to open a new PR to resolve this as I wasn't allowed to push to #855

@stevejpurves is this okay with you to merge? I made one edit besides the rST -> MyST markdown conversions required to solve merge conflicts from #863. You can see that change in a comment below.

Closes #855.

### Original PR

If you are using TLJH with named servers, it can be a requirement that the server is removed when culled. This PR is to expose the underlying IdleCuller option, allowing it to be set via `tljh-config`.

- [x] Add / update documentation
- [x] Add tests