### PR TITLE
docs(awscognito): add custom claims example

### DIFF
--- a/docs/howto/auth/awscognito.md
+++ b/docs/howto/auth/awscognito.md
@@ -126,3 +126,20 @@ For more information on `tljh-config`, see [](/topic/tljh-config).
    Jupyter interface used in this JupyterHub.
 5. **If this does not work** you can revert back to the default
    JupyterHub authenticator by following the steps in [](/howto/auth/firstuse).
+
+## Optionally using custom claims for group mapping
+
+If you use AWS Cognito to federate with an OIDC provider and you want to
+authorize your users based on e.g. their department claim, you have to make sure
+that the custom claim is provided as array.
+
+If it is not provided as array, there is an easy fix. Just add these lines to
+your `awscognito.py`:
+
+```python
+def claim_groups_key_func(user_data_resp_json):
+    return [user_data_resp_json['custom:department']]
+
+c.GenericOAuthenticator.claim_groups_key = claim_groups_key_func
+c.GenericOAuthenticator.allowed_groups = ["AA BB CC", "AA BB DD"]
+```


### PR DESCRIPTION
This is a recreation of https://github.com/jupyterhub/the-littlest-jupyterhub/pull/854, rebasing the PR having merge conflicts to add documentation in MyST markdown instead of the original change that was in .rst format.

Original commit message:

> After struggling with my custom department claim and getting helped in https://discourse.jupyter.org/t/genericauthenticator-with-cognito-how-to-check-for-department-match/18105/1 I wanted to give back to the community.

- Closes #854

---

@nodomain I hope this is okay with you, I want to push towards a new release and want your contribution merged for the changelog I'm writing.