### PR TITLE
Upgrade pip in hub env from 21.3 to to 23.1 when bootstrap script runs

### DIFF
--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -84,7 +84,7 @@ jobs:
         # Keep pip version pinning in sync with the one in bootstrap.py!
         # See changelog at https://pip.pypa.io/en/latest/news/#changelog
         run: |
-          python3 -m pip install -U "pip==21.3.*"
+          python3 -m pip install -U "pip==23.1.*"
           python3 -m pip install -r dev-requirements.txt
           python3 -m pip install -e .
           pip freeze

--- a/bootstrap/bootstrap.py
+++ b/bootstrap/bootstrap.py
@@ -479,7 +479,7 @@ def main():
     # Keep pip version pinning in sync with the one in unit-test.yml!
     # See changelog at https://pip.pypa.io/en/latest/news/#changelog
     logger.info("Upgrading pip...")
-    run_subprocess([hub_env_pip, "install", "--upgrade", "pip==21.3.*"])
+    run_subprocess([hub_env_pip, "install", "--upgrade", "pip==23.1.*"])
 
     # Install/upgrade TLJH installer
     tljh_install_cmd = [hub_env_pip, "install", "--upgrade"]


### PR DESCRIPTION
When the bootstrap script runs, we are upgrading pip in the hub env. Let's upgrade to pip `23.1.*` by default, up from `21.3.*`.

- Closes #889 