### PR TITLE
ensure hub env is on $PATH in jupyterhub service

### DIFF
--- a/tljh/systemd-units/jupyterhub.service
+++ b/tljh/systemd-units/jupyterhub.service
@@ -15,6 +15,7 @@ PrivateDevices=yes
 ProtectKernelTunables=yes
 ProtectKernelModules=yes
 Environment=TLJH_INSTALL_PREFIX={install_prefix}
+Environment=PATH={install_prefix}/hub/bin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 # Run upgrade-db before starting, in case Hub version has changed
 # This is a no-op when no db exists or no upgrades are needed
 ExecStart={python_interpreter_path} -m jupyterhub.app -f {jupyterhub_config_path} --upgrade-db


### PR DESCRIPTION
required for `--upgrade-db` to work, since it assumes `alembic` is on $PATH (it probably shouldn't, but that's a PR for jupyterhub)