### PR TITLE
docs: disable navigation with arrow keys

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,6 +38,7 @@ html_static_path = ["_static"]
 # pydata_sphinx_theme reference: https://pydata-sphinx-theme.readthedocs.io/en/stable/index.html
 html_theme = "pydata_sphinx_theme"
 html_theme_options = {
+    "navigation_with_keys": False,
     "icon_links": [
         {
             "name": "GitHub",


### PR DESCRIPTION
This fixes https://github.com/jupyterhub/the-littlest-jupyterhub/issues/565

Interestingly pydata-sphinx-theme turns this on by default.