### PR TITLE
Update nativeauthenticator, tmpauthenticator, and jupyterhub-configurator

### DIFF
--- a/tljh/requirements-hub-env.txt
+++ b/tljh/requirements-hub-env.txt
@@ -11,7 +11,7 @@
 jupyterhub>=4.0.0,<5
 jupyterhub-systemdspawner>=0.17.0,<5
 jupyterhub-firstuseauthenticator>=1.0.0,<2
-jupyterhub-nativeauthenticator>=1.1.0,<2
+jupyterhub-nativeauthenticator>=1.2.0,<2
 jupyterhub-ldapauthenticator>=1.3.2,<2
 jupyterhub-tmpauthenticator>=0.6.0,<0.7
 oauthenticator>=15.1.0,<16

--- a/tljh/requirements-hub-env.txt
+++ b/tljh/requirements-hub-env.txt
@@ -13,7 +13,7 @@ jupyterhub-systemdspawner>=0.17.0,<5
 jupyterhub-firstuseauthenticator>=1.0.0,<2
 jupyterhub-nativeauthenticator>=1.2.0,<2
 jupyterhub-ldapauthenticator>=1.3.2,<2
-jupyterhub-tmpauthenticator>=0.6.0,<0.7
+jupyterhub-tmpauthenticator>=1.0.0,<2
 oauthenticator>=15.1.0,<16
 jupyterhub-idle-culler>=1.2.1,<2
 git+https://github.com/yuvipanda/jupyterhub-configurator@996405d2a7017153d5abe592b8028fed7a1801bb

--- a/tljh/requirements-hub-env.txt
+++ b/tljh/requirements-hub-env.txt
@@ -16,7 +16,7 @@ jupyterhub-ldapauthenticator>=1.3.2,<2
 jupyterhub-tmpauthenticator>=0.6.0,<0.7
 oauthenticator>=15.1.0,<16
 jupyterhub-idle-culler>=1.2.1,<2
-git+https://github.com/yuvipanda/jupyterhub-configurator@317759e17c8e48de1b1352b836dac2a230536dba
+git+https://github.com/yuvipanda/jupyterhub-configurator@996405d2a7017153d5abe592b8028fed7a1801bb
 
 # pycurl is installed to improve reliability and performance for when JupyterHub
 # makes web requests. JupyterHub will use tornado's CurlAsyncHTTPClient when


### PR DESCRIPTION
- jupyterhub-tmpauthenticator is bumped from 0.6 to 1.0.0 and has breaking changes for users of it outlined [in the changelog](https://github.com/jupyterhub/tmpauthenticator/blob/main/CHANGELOG.md)
- jupyterhub-nativeauthenticator is bumped from 1.1.0 to 1.2.0 and comes with jupyterhub 4 support
- jupyterhub-configurator is bumped from 317759e to 996405d and comes with some button feedback