### PR TITLE
Add a Traefik configuration to listen on a specific address (#903)

### DIFF
--- a/docs/topic/tljh-config.md
+++ b/docs/topic/tljh-config.md
@@ -85,6 +85,19 @@ sudo tljh-config set https.port 8443
 sudo tljh-config reload proxy
 ```
 
+(tljh-set-listen-address)
+
+### Listen address
+
+Use `http.address` and `https.address` to set the addresses that TLJH will listen on,
+which is an empty address by default (it means it listens on all interfaces by default).
+
+```bash
+sudo tljh-config set http.address 127.0.0.1
+sudo tljh-config set https.address 127.0.0.1
+sudo tljh-config reload proxy
+```
+
 (tljh-set-user-lists)=
 
 ### User Lists

--- a/tests/test_traefik.py
+++ b/tests/test_traefik.py
@@ -240,3 +240,14 @@ def test_extra_config(tmpdir, tljh_dir):
     # Check that the defaults were updated by the extra config
     assert toml_cfg["log"]["level"] == "ERROR"
     assert toml_cfg["api"]["dashboard"] == True
+
+
+def test_listen_address(tmpdir, tljh_dir):
+    state_dir = config.STATE_DIR
+    config.set_config_value(config.CONFIG_FILE, "http.address", "127.0.0.1")
+    config.set_config_value(config.CONFIG_FILE, "https.address", "127.0.0.1")
+    traefik.ensure_traefik_config(str(state_dir))
+
+    cfg = _read_static_config(state_dir)
+    assert cfg["entryPoints"]['http']['address'] == "127.0.0.1:80"
+    assert cfg["entryPoints"]['https']['address'] == "127.0.0.1:443"

--- a/tests/test_traefik.py
+++ b/tests/test_traefik.py
@@ -254,5 +254,5 @@ def test_listen_address(tmpdir, tljh_dir):
     traefik.ensure_traefik_config(str(state_dir))
 
     cfg = _read_static_config(state_dir)
-    assert cfg["entryPoints"]['http']['address'] == "127.0.0.1:80"
-    assert cfg["entryPoints"]['https']['address'] == "127.0.0.1:443"
+    assert cfg["entryPoints"]["http"]["address"] == "127.0.0.1:80"
+    assert cfg["entryPoints"]["https"]["address"] == "127.0.0.1:443"

--- a/tests/test_traefik.py
+++ b/tests/test_traefik.py
@@ -244,8 +244,11 @@ def test_extra_config(tmpdir, tljh_dir):
 
 def test_listen_address(tmpdir, tljh_dir):
     state_dir = config.STATE_DIR
+    config.set_config_value(config.CONFIG_FILE, "https.enabled", True)
+
     config.set_config_value(config.CONFIG_FILE, "http.address", "127.0.0.1")
     config.set_config_value(config.CONFIG_FILE, "https.address", "127.0.0.1")
+    
     traefik.ensure_traefik_config(str(state_dir))
 
     cfg = _read_static_config(state_dir)

--- a/tests/test_traefik.py
+++ b/tests/test_traefik.py
@@ -245,10 +245,12 @@ def test_extra_config(tmpdir, tljh_dir):
 def test_listen_address(tmpdir, tljh_dir):
     state_dir = config.STATE_DIR
     config.set_config_value(config.CONFIG_FILE, "https.enabled", True)
+    config.set_config_value(config.CONFIG_FILE, "https.tls.key", "/path/to/ssl.key")
+    config.set_config_value(config.CONFIG_FILE, "https.tls.cert", "/path/to/ssl.cert")
 
     config.set_config_value(config.CONFIG_FILE, "http.address", "127.0.0.1")
     config.set_config_value(config.CONFIG_FILE, "https.address", "127.0.0.1")
-    
+
     traefik.ensure_traefik_config(str(state_dir))
 
     cfg = _read_static_config(state_dir)

--- a/tljh/config.py
+++ b/tljh/config.py
@@ -244,10 +244,15 @@ def check_hub_ready():
 
     base_url = load_config()["base_url"]
     base_url = base_url[:-1] if base_url[-1] == "/" else base_url
+    http_address = load_config()["http"]["address"]
     http_port = load_config()["http"]["port"]
+    # The default config is an empty address, so it binds on all interfaces.
+    # Test the connectivity on the local address.
+    if http_address == '':
+        http_address = '127.0.0.1'
     try:
         r = requests.get(
-            "http://127.0.0.1:%d%s/hub/api" % (http_port, base_url), verify=False
+            "http://%s:%d%s/hub/api" % (http_address, http_port, base_url), verify=False
         )
         if r.status_code != 200:
             print(f"Hub not ready: (HTTP status {r.status_code})")

--- a/tljh/config.py
+++ b/tljh/config.py
@@ -248,8 +248,8 @@ def check_hub_ready():
     http_port = load_config()["http"]["port"]
     # The default config is an empty address, so it binds on all interfaces.
     # Test the connectivity on the local address.
-    if http_address == '':
-        http_address = '127.0.0.1'
+    if http_address == "":
+        http_address = "127.0.0.1"
     try:
         r = requests.get(
             "http://%s:%d%s/hub/api" % (http_address, http_port, base_url), verify=False

--- a/tljh/configurer.py
+++ b/tljh/configurer.py
@@ -28,10 +28,12 @@ default = {
         "cpu": None,
     },
     "http": {
+        "address": "",
         "port": 80,
     },
     "https": {
         "enabled": False,
+        "address": "",
         "port": 443,
         "tls": {
             "cert": "",

--- a/tljh/traefik.toml.tpl
+++ b/tljh/traefik.toml.tpl
@@ -22,7 +22,7 @@ X-Xsrftoken = "redact"
 
 [entryPoints]
   [entryPoints.http]
-  address = ":{{ http['port'] }}"
+  address = "{{ http['address'] }}:{{ http['port'] }}"
 
   [entryPoints.http.transport.respondingTimeouts]
   idleTimeout = "10m"
@@ -33,7 +33,7 @@ X-Xsrftoken = "redact"
   scheme = "https"
 
   [entryPoints.https]
-  address = ":{{ https['port'] }}"
+  address = "{{ https['address'] }}:{{ https['port'] }}"
 
   [entryPoints.https.http.tls]
   options = "default"


### PR DESCRIPTION
This PR allows using `http.address` and `https.address` to set the addresses that TLJH will listen on,
which is an empty address by default (it means it listens on all interfaces by default, as it is the current behavior).

Tested and documented also!

Close #903 