### PR TITLE
Update systemdspawner from version 0.17.* to 1.*

### DIFF
--- a/tljh/requirements-hub-env.txt
+++ b/tljh/requirements-hub-env.txt
@@ -9,7 +9,7 @@
 # version release of tljh.
 #
 jupyterhub>=4.0.0,<5
-jupyterhub-systemdspawner>=0.17.0,<5
+jupyterhub-systemdspawner>=1.0.0,<2
 jupyterhub-firstuseauthenticator>=1.0.0,<2
 jupyterhub-nativeauthenticator>=1.2.0,<2
 jupyterhub-ldapauthenticator>=1.3.2,<2

--- a/tljh/user_creating_spawner.py
+++ b/tljh/user_creating_spawner.py
@@ -27,8 +27,10 @@ class CustomSpawner(SystemdSpawner):
         user.ensure_user(system_username)
         user.ensure_user_group(system_username, "jupyterhub-users")
         if self.user.admin:
+            self.disable_user_sudo = False
             user.ensure_user_group(system_username, "jupyterhub-admins")
         else:
+            self.disable_user_sudo = True
             user.remove_user_group(system_username, "jupyterhub-admins")
         if self.user_groups:
             for group, users in self.user_groups.items():


### PR DESCRIPTION
The breaking changes in SystemdSpawner are listed as:

>- Systemd v243+ is now required, and v245+ is recommended. Systemd v245 is available in for example Ubuntu 20.04+, Debian 11+, and Rocky/CentOS 9+.
>- Python 3.8+, JupyterHub 2.3.0+, and Tornado 5.1+ is now required.
>- `SystemdSpawner.disable_user_sudo` (influences systemd's `NoNewPrivileges`) now defaults to `True`, making the installation more secure by default.

I think only the `disable_user_sudo=True` as default change is the only possibly breaking change. I've added a commit to make admin users get it set to False and non-admin users get it set to True explicitly in TLJH now. This leads to the following breaking change:

If a non-admin jupyterhub user has been granted sudo permissions, without being granted jupyterhub admin status, then the user would then not be able to sudo any more.

I suggest that we suggest in the changelog that such users should also be granted jupyterhub admin status. This is something the user could acquire with sudo anyhow.

- Closes #904