### PR TITLE
Quote `pwd` to prevent error if dir has spaces

### DIFF
--- a/docs/contributing/dev-setup.md
+++ b/docs/contributing/dev-setup.md
@@ -24,7 +24,7 @@ The easiest & safest way to develop & test TLJH is with [Docker](https://www.doc
      --detach \
      --name=tljh-dev \
      --publish 12000:80 \
-     --mount type=bind,source=$(pwd),target=/srv/src \
+     --mount type=bind,source="$(pwd)",target=/srv/src \
      tljh-systemd
    ```
 


### PR DESCRIPTION
Very small change to the `docker run` command so that it works even if the path to your working directory has spaces. 😊