### PR TITLE
--force-reinstall old conda to ensure it's working before we try to install conda packages

### DIFF
--- a/tljh/conda.py
+++ b/tljh/conda.py
@@ -98,7 +98,7 @@ def install_miniconda(installer_path, prefix):
     fix_permissions(prefix)
 
 
-def ensure_conda_packages(prefix, packages, force=False):
+def ensure_conda_packages(prefix, packages, force_reinstall=False):
     """
     Ensure packages (from conda-forge) are installed in the conda prefix.
 
@@ -112,7 +112,7 @@ def ensure_conda_packages(prefix, packages, force=False):
 
     cmd = [conda_executable, "install", "--yes"]
 
-    if force:
+    if force_reinstall:
         # use force-reinstall, e.g. for conda/mamba to ensure everything is okay
         # avoids problems with RemoveError upgrading conda from old versions
         cmd += ["--force-reinstall"]

--- a/tljh/conda.py
+++ b/tljh/conda.py
@@ -113,7 +113,9 @@ def ensure_conda_packages(prefix, packages, force=False):
     cmd = [conda_executable, "install", "--yes"]
 
     if force:
-        cmd += ["--force"]
+        # use force-reinstall, e.g. for conda/mamba to ensure everything is okay
+        # avoids problems with RemoveError upgrading conda from old versions
+        cmd += ["--force-reinstall"]
 
     abspath = os.path.abspath(prefix)
 

--- a/tljh/conda.py
+++ b/tljh/conda.py
@@ -98,7 +98,7 @@ def install_miniconda(installer_path, prefix):
     fix_permissions(prefix)
 
 
-def ensure_conda_packages(prefix, packages):
+def ensure_conda_packages(prefix, packages, force=False):
     """
     Ensure packages (from conda-forge) are installed in the conda prefix.
 
@@ -110,13 +110,16 @@ def ensure_conda_packages(prefix, packages):
         # fallback on conda if mamba is not present (e.g. for mamba to install itself)
         conda_executable = os.path.join(prefix, "bin", "conda")
 
+    cmd = [conda_executable, "install", "--yes"]
+
+    if force:
+        cmd += ["--force"]
+
     abspath = os.path.abspath(prefix)
 
     utils.run_subprocess(
-        [
-            conda_executable,
-            "install",
-            "-y",
+        cmd
+        + [
             "-c",
             "conda-forge",  # Make customizable if we ever need to
             "--prefix",

--- a/tljh/installer.py
+++ b/tljh/installer.py
@@ -148,8 +148,8 @@ MAMBAFORGE_CHECKSUMS = {
 # minimum versions of packages
 MINIMUM_VERSIONS = {
     # if conda/mamba/pip are lower than this, upgrade them before installing the user packages
-    "mamba": "0.16.0",
-    "conda": "4.10",
+    "mamba": "1.4.2",
+    "conda": "23.3.1",
     "pip": "23.1.2",
     # minimum Python version (if not matched, abort to avoid big disruptive updates)
     "python": "3.9",

--- a/tljh/installer.py
+++ b/tljh/installer.py
@@ -249,6 +249,8 @@ def ensure_user_environment(user_requirements_txt_file):
                 # we _could_ explicitly pin Python here,
                 # but conda already does this by default
                 cf_pkgs_to_upgrade,
+                # use force to avoid RemoveError: 'requests' is a dependency of conda
+                force=True,
             )
         pypi_pkgs_to_upgrade = list(set(to_upgrade) & {"pip"})
         if pypi_pkgs_to_upgrade:


### PR DESCRIPTION
an old conda bug causes RemoveError: requests is a dependency of conda when installing other packages (closes #918).

<del>
Upgrading conda itself first avoids this bug (we _may_ want `--force` here, which some folks have seen required when conda itself is messed up, but let's avoid it for now). So we know that the version in 0.2.0 (4.10) is not actually new enough to work. It's unclear what the true minimum version is to fix this, but the important thing is that it will be upgraded if it's still the version in 0.2.0 (4.10), so pick the versions from today which we know works, and will be the version upgraded-to if an 0.2 install has yet to update conda.
</del>

`conda install --force-reinstall conda` is the fix for this, because `conda install conda` will fail to upgrade if we're in this situation. We could make it conditional on old condas, as I don't think this is likely to come up with more recent versions, but it should be safe in general to run this command.