### PR TITLE
breaking: update oauthenticator from 15.1.0 to >=16.0.2,<17, make tljh auth docs link out

### DIFF
--- a/docs/howto/auth/awscognito.md
+++ b/docs/howto/auth/awscognito.md
@@ -2,6 +2,18 @@
 
 # Authenticate using AWS Cognito
 
+```{warning}
+This documentation has not been updated recently, and a major version of
+OAuthenticator has been released since it was. Due to that, please only use this
+_as a complement_ to the official [OAuthenticator documentation].
+
+[OAuthenticator documentation]: https://oauthenticator.readthedocs.io/en/latest/tutorials/provider-specific-setup/providers/generic.html#setup-for-aws-cognito
+
+Going onwards, the goal is to ensure we have good documentation in the
+OAuthenticator project and reference that instead of maintaining similar
+documentation in this project also.
+```
+
 The **AWS Cognito Authenticator** lets users log into your JupyterHub using
 cognito user pools. To do so, you'll first need to register and configure a
 cognito user pool and app, and then provide information about this

--- a/docs/howto/auth/dummy.md
+++ b/docs/howto/auth/dummy.md
@@ -2,9 +2,11 @@
 
 # Authenticate _any_ user with a single shared password
 
+```{warning}
 The **Dummy Authenticator** lets _any_ user log in with the given password.
 This authenticator is **extremely insecure**, so do not use it if you can
 avoid it.
+```
 
 ## Enabling the authenticator
 

--- a/docs/howto/auth/firstuse.md
+++ b/docs/howto/auth/firstuse.md
@@ -2,6 +2,18 @@
 
 # Let users choose a password when they first log in
 
+```{warning}
+This documentation is not being updated regularly and may be out of date. Due to
+that, please only use this _as a complement_ to the official
+[FirstUseAuthenticator documentation].
+
+[FirstUseAuthenticator documentation]: https://github.com/jupyterhub/firstuseauthenticator#readme
+
+Going onwards, the goal is to ensure we have good documentation in the
+FirstUseAuthenticator project and reference that instead of maintaining similar
+documentation in this project also.
+```
+
 The **First Use Authenticator** lets users choose their own password.
 Upon their first log-in attempt, whatever password they use will be stored
 as their password for subsequent log in attempts. This is

--- a/docs/howto/auth/github.md
+++ b/docs/howto/auth/github.md
@@ -2,6 +2,18 @@
 
 # Authenticate using GitHub Usernames
 
+```{warning}
+This documentation has not been updated recently, and a major version of
+OAuthenticator has been released since it was. Due to that, please only use this
+_as a complement_ to the official [OAuthenticator documentation].
+
+[OAuthenticator documentation]: https://oauthenticator.readthedocs.io/en/latest/tutorials/provider-specific-setup/providers/github.html
+
+Going onwards, the goal is to ensure we have good documentation in the
+OAuthenticator project and reference that instead of maintaining similar
+documentation in this project also.
+```
+
 The **GitHub Authenticator** lets users log into your JupyterHub using their
 GitHub user ID / password. To do so, you'll first need to register an
 application with GitHub, and then provide information about this

--- a/docs/howto/auth/google.md
+++ b/docs/howto/auth/google.md
@@ -2,6 +2,18 @@
 
 # Authenticate using Google
 
+```{warning}
+This documentation has not been updated recently, and a major version of
+OAuthenticator has been released since it was. Due to that, please only use this
+_as a complement_ to the official [OAuthenticator documentation].
+
+[OAuthenticator documentation]: https://oauthenticator.readthedocs.io/en/latest/tutorials/provider-specific-setup/providers/google.html
+
+Going onwards, the goal is to ensure we have good documentation in the
+OAuthenticator project and reference that instead of maintaining similar
+documentation in this project also.
+```
+
 The **Google OAuthenticator** lets users log into your JupyterHub using their
 Google user ID / password. To do so, you'll first need to register an
 application with Google, and then provide information about this

--- a/docs/howto/auth/nativeauth.md
+++ b/docs/howto/auth/nativeauth.md
@@ -2,6 +2,18 @@
 
 # Let users sign up with a username and password
 
+```{warning}
+This documentation is not being updated regularly and may be out of date. Due to
+that, please only use this _as a complement_ to the official
+[NativeAuthenticator documentation].
+
+[NativeAuthenticator documentation]: https://native-authenticator.readthedocs.io/en/latest/
+
+Going onwards, the goal is to ensure we have good documentation in the
+NativeAuthenticator project and reference that instead of maintaining similar
+documentation in this project also.
+```
+
 The **Native Authenticator** lets users signup for creating a new username
 and password.
 When they signup, they won't be able to login until they are authorized by an

--- a/tljh/requirements-hub-env.txt
+++ b/tljh/requirements-hub-env.txt
@@ -14,7 +14,7 @@ jupyterhub-firstuseauthenticator>=1.0.0,<2
 jupyterhub-nativeauthenticator>=1.2.0,<2
 jupyterhub-ldapauthenticator>=1.3.2,<2
 jupyterhub-tmpauthenticator>=1.0.0,<2
-oauthenticator>=15.1.0,<16
+oauthenticator>=16.0.2,<17
 jupyterhub-idle-culler>=1.2.1,<2
 
 # pycurl is installed to improve reliability and performance for when JupyterHub


### PR DESCRIPTION
While I think it would be good if we could update all the authentication documentation, I don't think we should try get that done before a release. So instead of doing that, I made disclaimers to the documentation we had, suggesting that for example the OAuthenticator project's documentation should be used pirmarily and the tljh provided docs should be used as a complement only.

This is a preview of the warning, and you can preview it in the read the docs PR build [here](https://the-littlest-jupyterhub--924.org.readthedocs.build/en/924/howto/auth/github.html):

![image](https://github.com/jupyterhub/the-littlest-jupyterhub/assets/3837114/a07d0d20-1a51-4dcb-94ba-e911ae29b13e)
