### PR TITLE
Update Notebook, JupyterLab, Jupyter Resource Usage

### DIFF
--- a/integration-tests/test_extensions.py
+++ b/integration-tests/test_extensions.py
@@ -1,3 +1,4 @@
+import re
 import subprocess
 
 

--- a/integration-tests/test_extensions.py
+++ b/integration-tests/test_extensions.py
@@ -7,7 +7,7 @@ def test_serverextensions():
     """
     # jupyter-serverextension writes to stdout and stderr weirdly
     proc = subprocess.run(
-        ["/opt/tljh/user/bin/jupyter-serverextension", "list", "--sys-prefix"],
+        ["/opt/tljh/user/bin/jupyter-server", "extension", "list", "--sys-prefix"],
         stderr=subprocess.PIPE,
     )
 

--- a/integration-tests/test_extensions.py
+++ b/integration-tests/test_extensions.py
@@ -41,6 +41,6 @@ def test_labextensions():
     for e in extensions:
         # jupyter labextension lists outputs to stderr
         out = proc.stderr.decode()
-        enabled_ok_pattern = re.compile(fr"{e}.*enabled.*OK")
+        enabled_ok_pattern = re.compile(rf"{e}.*enabled.*OK")
         matches = enabled_ok_pattern.search(out)
         assert matches is not None

--- a/integration-tests/test_extensions.py
+++ b/integration-tests/test_extensions.py
@@ -14,7 +14,7 @@ def test_serverextensions():
 
     extensions = [
         "jupyterlab",
-        # "nbgitpuller",
+        "nbgitpuller",
         "jupyter_resource_usage",
     ]
 

--- a/integration-tests/test_extensions.py
+++ b/integration-tests/test_extensions.py
@@ -12,7 +12,7 @@ def test_serverextensions():
     )
 
     extensions = [
-        "jupyterlab 4.",
+        "jupyterlab",
         "nbgitpuller 1.",
         "jupyter_resource_usage",
     ]

--- a/integration-tests/test_extensions.py
+++ b/integration-tests/test_extensions.py
@@ -39,9 +39,8 @@ def test_labextensions():
     ]
 
     for e in extensions:
-        assert f"{e} \x1b[32m enabled \x1b[0m" in proc.stdout.decode()
-
-    # Ensure we have 'OK' messages in our stdout, to make sure everything is importable
-    assert proc.stderr.decode() == "      - Validating: \x1b[32mOK\x1b[0m\n" * len(
-        extensions
-    )
+        # jupyter labextension lists outputs to stderr
+        out = proc.stderr.decode()
+        enabled_ok_pattern = re.compile(fr"{e}.*enabled.*OK")
+        matches = enabled_ok_pattern.search(proc.stderr.decode())
+        assert matches is not None

--- a/integration-tests/test_extensions.py
+++ b/integration-tests/test_extensions.py
@@ -21,21 +21,21 @@ def test_serverextensions():
         assert e in proc.stderr.decode()
 
 
-def test_nbextensions():
+def test_labextensions():
     """
-    Validate nbextensions we want are installed & enabled
+    Validate JupyterLab extensions we want are installed & enabled
     """
-    # jupyter-nbextension writes to stdout and stderr weirdly
+    # jupyter-labextension writes to stdout and stderr weirdly
     proc = subprocess.run(
-        ["/opt/tljh/user/bin/jupyter-nbextension", "list", "--sys-prefix"],
+        ["/opt/tljh/user/bin/jupyter-labextension", "list"],
         stderr=subprocess.PIPE,
         stdout=subprocess.PIPE,
     )
 
     extensions = [
-        "jupyter_resource_usage/main",
-        # This is what ipywidgets nbextension is called
-        "jupyter-js-widgets/extension",
+        "@jupyter-server/resource-usage",
+        # This is what ipywidgets lab extension is called
+        "@jupyter-widgets/jupyterlab-manager",
     ]
 
     for e in extensions:

--- a/integration-tests/test_extensions.py
+++ b/integration-tests/test_extensions.py
@@ -12,7 +12,7 @@ def test_serverextensions():
     )
 
     extensions = [
-        "jupyterlab 3.",
+        "jupyterlab 4.",
         "nbgitpuller 1.",
         "jupyter_resource_usage",
     ]

--- a/integration-tests/test_extensions.py
+++ b/integration-tests/test_extensions.py
@@ -13,7 +13,7 @@ def test_serverextensions():
 
     extensions = [
         "jupyterlab",
-        "nbgitpuller",
+        # "nbgitpuller",
         "jupyter_resource_usage",
     ]
 

--- a/integration-tests/test_extensions.py
+++ b/integration-tests/test_extensions.py
@@ -42,5 +42,5 @@ def test_labextensions():
         # jupyter labextension lists outputs to stderr
         out = proc.stderr.decode()
         enabled_ok_pattern = re.compile(fr"{e}.*enabled.*OK")
-        matches = enabled_ok_pattern.search(proc.stderr.decode())
+        matches = enabled_ok_pattern.search(out)
         assert matches is not None

--- a/integration-tests/test_extensions.py
+++ b/integration-tests/test_extensions.py
@@ -13,7 +13,7 @@ def test_serverextensions():
 
     extensions = [
         "jupyterlab",
-        "nbgitpuller 1.",
+        "nbgitpuller",
         "jupyter_resource_usage",
     ]
 

--- a/tljh/requirements-user-env-extras.txt
+++ b/tljh/requirements-user-env-extras.txt
@@ -8,11 +8,11 @@
 #          the requirements-txt-fixer pre-commit hook that sorted them and made
 #          our integration tests fail.
 #
-notebook==6.*
-jupyterlab==3.*
+notebook==7.*
+jupyterlab==4.*
 # nbgitpuller for easily pulling in Git repositories
 nbgitpuller==1.*
 # jupyter-resource-usage to show people how much RAM they are using
-jupyter-resource-usage==0.7.*
+jupyter-resource-usage==1.*
 # Most people consider ipywidgets to be part of the core notebook experience
 ipywidgets==8.*


### PR DESCRIPTION
Update Jupyter Notebook, JupyterLab and Jupyter Resource Usage to the latest major releases:

- [x] `notebook`: https://jupyter-notebook.readthedocs.io/en/stable/changelog.html
- [x] `jupyterlab`: https://jupyterlab.readthedocs.io/en/latest/getting_started/changelog.html#v4-0
- [x] `jupyter-resource-usage`: https://github.com/jupyter-server/jupyter-resource-usage/releases/tag/v1.0.0
- [x] Pending a new `nbgitpuller` release: https://github.com/jupyterhub/nbgitpuller/pull/315