### PR TITLE
Fix URL syntax in nativeauth.md

### DIFF
--- a/docs/howto/auth/nativeauth.md
+++ b/docs/howto/auth/nativeauth.md
@@ -42,4 +42,4 @@ tljh-config reload
 
 ## Optional features
 
-More optional features are available on the `authenticator documentation <https://native-authenticator.readthedocs.io/en/latest/>`
+More optional features are available on the [authenticator documentation](https://native-authenticator.readthedocs.io/en/latest/)


### PR DESCRIPTION
The URL at the bottom of the page https://tljh.jupyter.org/en/latest/howto/auth/nativeauth.html does not show correctly. The syntax was not markdown -> the pull request simply fixes that.