### PR TITLE
Re-install conda/mamba for every tljh upgrade (doesn't imply upgrade)

### DIFF
--- a/.github/integration-test.py
+++ b/.github/integration-test.py
@@ -167,7 +167,15 @@ def run_test(
         command = f"python3 /srv/src/bootstrap/bootstrap.py --version={upgrade_from}"
         run_command(container_name, command)
 
+        # show user environment
+        command = "/opt/tljh/user/bin/mamba list"
+        run_command(container_name, command)
+
     command = f"python3 /srv/src/bootstrap/bootstrap.py {' '.join(installer_args)}"
+    run_command(container_name, command)
+
+    # show user environment (again if upgrade)
+    command = "/opt/tljh/user/bin/mamba list"
     run_command(container_name, command)
 
     # Install pkgs from requirements in hub's pip, where
@@ -175,7 +183,7 @@ def run_test(
     command = "/opt/tljh/hub/bin/python3 -m pip install -r /srv/src/integration-tests/requirements.txt"
     run_command(container_name, command)
 
-    # show environment
+    # show hub environment
     command = "/opt/tljh/hub/bin/python3 -m pip freeze"
     run_command(container_name, command)
 

--- a/integration-tests/plugins/simplest/tljh_simplest.py
+++ b/integration-tests/plugins/simplest/tljh_simplest.py
@@ -12,7 +12,7 @@ def tljh_extra_user_conda_packages():
 
 @hookimpl
 def tljh_extra_user_pip_packages():
-    return ["django"]
+    return ["simplejson"]
 
 
 @hookimpl

--- a/integration-tests/test_simplest_plugin.py
+++ b/integration-tests/test_simplest_plugin.py
@@ -20,7 +20,7 @@ def test_tljh_extra_user_conda_packages():
 
 
 def test_tljh_extra_user_pip_packages():
-    subprocess.check_call([f"{USER_ENV_PREFIX}/bin/python3", "-c", "import django"])
+    subprocess.check_call([f"{USER_ENV_PREFIX}/bin/python3", "-c", "import simplejson"])
 
 
 def test_tljh_extra_hub_pip_packages():

--- a/tljh/installer.py
+++ b/tljh/installer.py
@@ -242,11 +242,10 @@ def ensure_user_environment(user_requirements_txt_file):
                 )
                 to_upgrade.append(pkg)
 
-    # force reinstall conda/mamba to ensure a basically consistent env
-    # avoids issues with RemoveError: 'requests' is a dependency of conda
-    # only do this for 'old' conda versions known to have a problem
-    # we don't know how old, but we know 4.10 is affected and 23.1 is not
-    if not is_fresh_install and V(package_versions.get("conda", "0")) < V("23.1"):
+    # force reinstall conda/mamba to ensure conda doesn't raise error
+    # "RemoveError: 'requests' is a dependency of conda" later on when
+    # conda/mamba is used to install/upgrade something
+    if not is_fresh_install:
         # force-reinstall doesn't upgrade packages
         # it reinstalls them in-place
         # only reinstall packages already present


### PR DESCRIPTION
We have previously re-installed (without upgrading) conda and mamba, and done it based on specific versions. I think we are required to do this uncodntionally though. I think based https://github.com/conda/conda/issues/12366#issuecomment-1466144007 that since tljh make use of both pip and conda/mamba to install packages via plugins, even though we mostly use pip, we must do this re-install to ensure conda/mamba is functional before an tljh upgrade.

I think we end up with `requests` installed via pip during the initial setup of tljh, and that sets us up for issues when we are to make an upgrade later when conda/mamba is being used via plugins. I think the reason we didn't have this error before in tests, but do now, relates to new versions of `openssl` have been released, and that conda/mamba automatically upgrades them.

- Fixes #944 
