### PR TITLE
Fix typo and replace word

### DIFF
--- a/docs/install/amazon.md
+++ b/docs/install/amazon.md
@@ -139,7 +139,7 @@ Let's create the server on which we can run JupyterHub.
     SSH to connect (port 22).
 
     If you have never used your Amazon account before, you'll have to select
-    **Create a new security group**. You should give it a disitnguishing name
+    **Create a new security group**. You should give it a distinctive name
     under **Security group name**
     such as `ssh_web` for future reference. If you have, one from before you can
     select it and adjust it to have the rules you need, if you prefer.


### PR DESCRIPTION
This PR fixes a typo and replaces the word. The typo is of "distinguishing", but "distinctive" makes more sense to me in the context of the sentence it is in. Let me know if you prefer just fixing the typo and leaving "distinguishing".

Before (from [Installing on Amazon Web Services](https://tljh.jupyter.org/en/latest/install/amazon.html)):

<img src="https://github.com/jupyterhub/the-littlest-jupyterhub/assets/933552/ad735e26-4d94-4975-b638-141cf7930843" width="640">

After:

<img src="https://github.com/jupyterhub/the-littlest-jupyterhub/assets/933552/12661a5b-5aa1-4cc0-be63-b52f611c1714" width="640">