### PR TITLE
Reword documentation sentence

### DIFF
--- a/docs/install/amazon.md
+++ b/docs/install/amazon.md
@@ -141,8 +141,8 @@ Let's create the server on which we can run JupyterHub.
     If you have never used your Amazon account before, you'll have to select
     **Create a new security group**. You should give it a disitnguishing name
     under **Security group name**
-    such as `ssh_web` for future reference. If you have, one from before you can
-    select it and adjust it to have the rules you need, if you prefer.
+    such as `ssh_web` for future reference. If you already have a security group,
+    you can select it and adjust it to have the rules you need, if you prefer.
 
     The rules will default to include `SSH`. Leave that there, and then click on
     the **Add Rule** button. Under **Type** for the new rule, change the field


### PR DESCRIPTION
This PR adjusts the wording of a sentence in the [Installing on Amazon Web Services](https://tljh.jupyter.org/en/latest/install/amazon.html) page. I was initially going to just move the comma in the original sentence ("If you have, one from before you can select it and" --> "If you have one from before, you can select it and"), but then I thought the wording proposed in this PR is more clear.

If you prefer a different change, such as the comma relocation, I am happy to modify the PR.

Before:

<img src="https://github.com/jupyterhub/the-littlest-jupyterhub/assets/933552/b14a6fa1-2abb-4007-96b3-65a829327c48" width="640">

After:

<img src="https://github.com/jupyterhub/the-littlest-jupyterhub/assets/933552/444edf88-4084-40b2-b9b1-a63e0d2c9599" width="640">