### PR TITLE
tests: fix to catch test failure earlier when they really happen

### DIFF
--- a/integration-tests/test_hub.py
+++ b/integration-tests/test_hub.py
@@ -59,9 +59,9 @@ async def test_user_code_execute():
 
     async with User(username, HUB_URL, partial(login_dummy, password="")) as u:
         assert await u.login()
-        await u.ensure_server_simulate(timeout=60, spawn_refresh_time=5)
-        await u.start_kernel()
-        await u.assert_code_output("5 * 4", "20", 5, 5)
+        assert await u.ensure_server_simulate(timeout=60, spawn_refresh_time=5)
+        assert await u.start_kernel()
+        assert await u.assert_code_output("5 * 4", "20", 5, 5)
 
 
 async def test_user_server_started_with_custom_base_url():


### PR DESCRIPTION
Just something observed when trying to resolve #974, which is fixed by jupyterhub 4.1.5 release and work in #962 by @jrdnbradford.