### PR TITLE
Added missing details on how to add custom domain from manual HTTPS  configuration

### DIFF
--- a/docs/howto/admin/https.md
+++ b/docs/howto/admin/https.md
@@ -89,6 +89,7 @@ If so, you can tell your deployment to use these files:
 sudo tljh-config set https.enabled true
 sudo tljh-config set https.tls.key /etc/mycerts/mydomain.key
 sudo tljh-config set https.tls.cert /etc/mycerts/mydomain.cert
+sudo tljh-config add-item https.tls.domains yourhub.yourdomain.edu
 ```
 
 Once you have loaded this, your config should look like:
@@ -103,6 +104,8 @@ https:
   tls:
     key: /etc/mycerts/mydomain.key
     cert: /etc/mycerts/mydomain.cert
+    domains:
+      - yourhub.yourdomain.edu
 ```
 
 Finally, you can reload the proxy to load the new configuration:


### PR DESCRIPTION
While trying to configure manual HTTPS for TLJH i found that details on how to had custom domain was missing, for easy understanding and clarity had to propose this change.