### PR TITLE
fix `-m` invocation of jupyterhub

### DIFF
--- a/docs/howto/admin/systemd.md
+++ b/docs/howto/admin/systemd.md
@@ -23,7 +23,7 @@ PrivateDevices=yes
 ProtectKernelTunables=yes
 ProtectKernelModules=yes
 Environment=TLJH_INSTALL_PREFIX=/opt/tljh
-ExecStart=/opt/tljh/hub/bin/python3 -m jupyterhub.app -f jupyterhub_config.py --upgrade-db
+ExecStart=/opt/tljh/hub/bin/python3 -m jupyterhub -f jupyterhub_config.py --upgrade-db
 
 [Install]
 WantedBy=multi-user.target

--- a/tljh/systemd-units/jupyterhub.service
+++ b/tljh/systemd-units/jupyterhub.service
@@ -18,7 +18,7 @@ Environment=TLJH_INSTALL_PREFIX={install_prefix}
 Environment=PATH={install_prefix}/hub/bin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 # Run upgrade-db before starting, in case Hub version has changed
 # This is a no-op when no db exists or no upgrades are needed
-ExecStart={python_interpreter_path} -m jupyterhub.app -f {jupyterhub_config_path} --upgrade-db
+ExecStart={python_interpreter_path} -m jupyterhub -f {jupyterhub_config_path} --upgrade-db
 
 [Install]
 # Start service when system boots


### PR DESCRIPTION
-m jupyterhub.app results in multiple JupyterHub classes being defined and jupyterhub.app.JupyterHub never being instantiated

closes #987 