### PR TITLE
Update base user environment to miniforge 24.7.1-0 (Python 3.12)

### DIFF
--- a/docs/topic/installer-actions.md
+++ b/docs/topic/installer-actions.md
@@ -26,7 +26,7 @@ sudo rm -rf /opt/tljh/hub
 
 ## User environment
 
-By default, a `mambaforge` conda environment is installed in `/opt/tljh/user`. This contains
+By default, a `miniforge` conda environment is installed in `/opt/tljh/user`. This contains
 the notebook interface used to launch all users, and the various packages available to all
 users. The environment is owned by the `root` user. JupyterHub admins may use
 to `sudo -E conda install` or `sudo -E pip install` packages into this environment.

--- a/tests/test_conda.py
+++ b/tests/test_conda.py
@@ -14,9 +14,9 @@ from tljh import conda, installer
 @pytest.fixture(scope="module")
 def prefix():
     """
-    Provide a temporary directory with a mambaforge conda environment
+    Provide a temporary directory with a conda environment
     """
-    installer_url, checksum = installer._mambaforge_url()
+    installer_url, checksum = installer._miniforge_url()
     with tempfile.TemporaryDirectory() as tmpdir:
         with conda.download_miniconda_installer(
             installer_url, checksum

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -46,12 +46,12 @@ def test_ensure_admins(tljh_dir, admins, expected_config):
 
 
 def setup_conda(distro, version, prefix):
-    """Install mambaforge or miniconda in a prefix"""
+    """Install miniforge or miniconda in a prefix"""
     if distro == "mambaforge":
-        installer_url, _ = installer._mambaforge_url(version)
+        installer_url, _ = installer._miniforge_url(version)
+        installer_url = installer_url.replace("Miniforge3", "Mambaforge")
     elif distro == "miniforge":
-        installer_url, _ = installer._mambaforge_url(version)
-        installer_url = installer_url.replace("Mambaforge", "Miniforge3")
+        installer_url, _ = installer._miniforge_url(version)
     elif distro == "miniconda":
         arch = os.uname().machine
         installer_url = (
@@ -124,9 +124,9 @@ def _specifier(version):
             None,
             None,
             {
-                "python": "3.10.*",
-                "conda": "23.1.0",
-                "mamba": "1.4.1",
+                "python": "3.12.*",
+                "conda": "24.5.0",
+                "mamba": "1.5.8",
             },
         ),
         # previous install, 1.0

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -125,8 +125,8 @@ def _specifier(version):
             None,
             {
                 "python": "3.12.*",
-                "conda": "24.5.0",
-                "mamba": "1.5.8",
+                "conda": "24.7.1",
+                "mamba": "1.5.9",
             },
         ),
         # previous install, 1.0

--- a/tljh/installer.py
+++ b/tljh/installer.py
@@ -136,13 +136,13 @@ def ensure_usergroups():
         f.write("Defaults exempt_group = jupyterhub-admins\n")
 
 
-# Install mambaforge using an installer from
+# Install miniforge using an installer from
 # https://github.com/conda-forge/miniforge/releases
-MAMBAFORGE_VERSION = "23.1.0-1"
+MINIFORGE_VERSION = "24.5.0-0"
 # sha256 checksums
-MAMBAFORGE_CHECKSUMS = {
-    "aarch64": "d9d89c9e349369702171008d9ee7c5ce80ed420e5af60bd150a3db4bf674443a",
-    "x86_64": "cfb16c47dc2d115c8b114280aa605e322173f029fdb847a45348bf4bd23c62ab",
+MINIFORGE_CHECKSUMS = {
+    "aarch64": "848f2d6917c473b1091e31a51241a7626d4dac4b90809a9b2ed937e0cea18d87",
+    "x86_64": "a754b435830e1c038dada434873ad69a99970a4ea17a68d3bbcade0a37c8c8fb",
 }
 
 # minimum versions of packages
@@ -156,22 +156,22 @@ MINIMUM_VERSIONS = {
 }
 
 
-def _mambaforge_url(version=MAMBAFORGE_VERSION, arch=None):
-    """Return (URL, checksum) for mambaforge download for a given version and arch
+def _miniforge_url(version=MINIFORGE_VERSION, arch=None):
+    """Return (URL, checksum) for miniforge download for a given version and arch
 
     Default values provided for both version and arch
     """
     if arch is None:
         arch = os.uname().machine
-    installer_url = "https://github.com/conda-forge/miniforge/releases/download/{v}/Mambaforge-{v}-Linux-{arch}.sh".format(
+    installer_url = "https://github.com/conda-forge/miniforge/releases/download/{v}/Miniforge3-{v}-Linux-{arch}.sh".format(
         v=version,
         arch=arch,
     )
     # Check system architecture, set appropriate installer checksum
-    checksum = MAMBAFORGE_CHECKSUMS.get(arch)
+    checksum = MINIFORGE_CHECKSUMS.get(arch)
     if not checksum:
         raise ValueError(
-            f"Unsupported architecture: {arch}. TLJH only supports {','.join(MAMBAFORGE_CHECKSUMS.keys())}"
+            f"Unsupported architecture: {arch}. TLJH only supports {','.join(MINIFORGE_CHECKSUMS.keys())}"
         )
     return installer_url, checksum
 
@@ -198,7 +198,7 @@ def ensure_user_environment(user_requirements_txt_file):
             raise OSError(msg)
 
         logger.info("Downloading & setting up user environment...")
-        installer_url, installer_sha256 = _mambaforge_url()
+        installer_url, installer_sha256 = _miniforge_url()
         with conda.download_miniconda_installer(
             installer_url, installer_sha256
         ) as installer_path:

--- a/tljh/installer.py
+++ b/tljh/installer.py
@@ -138,11 +138,11 @@ def ensure_usergroups():
 
 # Install miniforge using an installer from
 # https://github.com/conda-forge/miniforge/releases
-MINIFORGE_VERSION = "24.5.0-0"
+MINIFORGE_VERSION = "24.7.1-0"
 # sha256 checksums
 MINIFORGE_CHECKSUMS = {
-    "aarch64": "848f2d6917c473b1091e31a51241a7626d4dac4b90809a9b2ed937e0cea18d87",
-    "x86_64": "a754b435830e1c038dada434873ad69a99970a4ea17a68d3bbcade0a37c8c8fb",
+    "aarch64": "7a3372268b45679584043b4ba1e0318ee5027384a8d330f2d991b14d815d6a6d",
+    "x86_64": "b64f77042cf8eafd31ced64f9253a74fb85db63545fe167ba5756aea0e8125be",
 }
 
 # minimum versions of packages


### PR DESCRIPTION
mambaforge-named installers are deprecated, as mamba has been in miniforge for some time now, so they will be merged. Mambaforge releases will stop later this year.