### PR TITLE
consolidate lock file handling

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,3 @@
-filelock
 packaging
 pytest
 pytest-cov

--- a/integration-tests/requirements.txt
+++ b/integration-tests/requirements.txt
@@ -1,4 +1,3 @@
-filelock
 pytest
 pytest-cov
 pytest-asyncio

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(
         "jinja2",
         "pluggy==1.*",
         "backoff",
+        "filelock",
         "requests",
         "bcrypt",
         "jupyterhub-traefik-proxy==1.*",

--- a/tljh/requirements-hub-env.txt
+++ b/tljh/requirements-hub-env.txt
@@ -26,6 +26,3 @@ jupyterhub-idle-culler>=1.2.1,<2
 # ref: https://github.com/jupyterhub/the-littlest-jupyterhub/issues/289
 #
 pycurl>=7.45.2,<8
-
-# filelock is used to help us do atomic operations on config file(s)
-filelock>=3.15.4,<4


### PR DESCRIPTION
- makes filelock a dependency of tljh (missing this is the reason for the in-function imports)
- adds config_file_lock context manager to re-use
- moves filelock import to module level
- fixes exit codes, stderr messages

small polish on #976 
