### PR TITLE
ci: cache pip only when no container is used

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -126,6 +126,9 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
+          cache: pip
+          cache-dependency-path: |
+            integration-tests/requirements.txt
 
       # FIXME: The test_bootstrap.py script has duplicated logic to run build
       #        and start images and run things in them. This makes tests slower,

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -69,21 +69,6 @@ jobs:
           python3 -m venv /srv/venv
           echo '/srv/venv/bin' >> $GITHUB_PATH
 
-      # WARNING: This action loads a cache of pip dependencies based on the
-      #          declared key, and it will save a cache for that key on job
-      #          completion. Make sure to update the key to bust the cache
-      #          properly if you make a change that should influence it.
-      - name: Load cached Python dependencies
-        uses: actions/cache@v4
-        with:
-          path: /srv/venv/
-          key: >-
-            pip-
-            ${{ matrix.runs_on }}-
-            ${{ matrix.ubuntu_version }}-
-            ${{ matrix.python_version }}-
-            ${{ hashFiles('setup.py', 'dev-requirements.txt', '.github/workflows/unit-test.yaml') }}
-
       - name: Install Python dependencies
         run: |
           pip install -r dev-requirements.txt


### PR DESCRIPTION
I think https://github.com/jupyterhub/the-littlest-jupyterhub/actions/runs/10964462847/job/30448138728 failed due to caching issues. I want to reduce complexity by not using cache when we not only configure runs-on but also container. Debugging failures in this complicated CI system is hard, needing to first rule out its about cache issues makes it even harder, so I'd rather let it take a few more seconds.