### PR TITLE
Test upgrade from 1.*

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -54,6 +54,9 @@ jobs:
           - name: "Ubuntu 22.04, Py 3.10, from 0.2.0"
             distro_image: "ubuntu:22.04"
             extra_flags: --upgrade-from=0.2.0
+          - name: "Ubuntu 22.04, Py 3.10, from 1.*"
+            distro_image: "ubuntu:22.04"
+            extra_flags: --upgrade-from=1
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Currently covered by `latest`, but won't be when 2.0.0 is released