### PR TITLE
hub env: avoid installing pycurl using wheel with an issue

### DIFF
--- a/tljh/requirements-hub-env.txt
+++ b/tljh/requirements-hub-env.txt
@@ -25,4 +25,7 @@ jupyterhub-idle-culler>=1.4.0,<2
 # ref: https://www.tornadoweb.org/en/stable/httpclient.html#module-tornado.simple_httpclient
 # ref: https://github.com/jupyterhub/the-littlest-jupyterhub/issues/289
 #
-pycurl>=7.45.3,<8
+# FIXME: pycurl is installed from source without its wheel for 7.45.3 has an
+#        issue reported in https://github.com/pycurl/pycurl/issues/834.
+#
+pycurl>=7.45.3,<8 --no-binary=pycurl


### PR DESCRIPTION
I think this may fix some issues for people, its something we do for z2jh's images for example.