### PR TITLE
hub env: pin to jupyterhub 5.1.0

### DIFF
--- a/tljh/requirements-hub-env.txt
+++ b/tljh/requirements-hub-env.txt
@@ -8,7 +8,7 @@
 # If a dependency is bumped to a new major version, we should make a major
 # version release of tljh.
 #
-jupyterhub>=5.2.0,<6
+jupyterhub>=5.1.0,<5.2.0
 jupyterhub-systemdspawner>=1.0.1,<2
 jupyterhub-firstuseauthenticator>=1.1.0,<2
 jupyterhub-nativeauthenticator>=1.3.0,<2


### PR DESCRIPTION
I'm not sure why we have tests failing in main now.

The only change made was #1004 which I merged without waiting for tests to go green as I reasoned they couldn't be impacted by the change, and I don't think they were but that the tests went red because of something else, such as jupyterhub 5.2.0 being released?