### PR TITLE
Update jupyterhub pinning to >=5.2.0,<6 from ==5.1.0

### DIFF
--- a/tljh/requirements-hub-env.txt
+++ b/tljh/requirements-hub-env.txt
@@ -9,7 +9,7 @@
 # version release of tljh.
 #
 jupyterhub>=5.2.0,<6
-jupyterhub-systemdspawner>=1.0.1,<2
+jupyterhub-systemdspawner>=1.0.2,<2
 jupyterhub-firstuseauthenticator>=1.1.0,<2
 jupyterhub-nativeauthenticator>=1.3.0,<2
 jupyterhub-ldapauthenticator>=2.0.0,<3

--- a/tljh/requirements-hub-env.txt
+++ b/tljh/requirements-hub-env.txt
@@ -8,7 +8,7 @@
 # If a dependency is bumped to a new major version, we should make a major
 # version release of tljh.
 #
-jupyterhub>=5.1.0,<5.2.0
+jupyterhub>=5.2.0,<6
 jupyterhub-systemdspawner>=1.0.1,<2
 jupyterhub-firstuseauthenticator>=1.1.0,<2
 jupyterhub-nativeauthenticator>=1.3.0,<2


### PR DESCRIPTION
## Something is wrong

- systemdspawner is not erroring on tests with JupyterHub 5.2.0 ([test run](https://github.com/jupyterhub/systemdspawner/actions/runs/11424844766/job/31785717454))
- hubtraf is not erroring on tests with JupyterHub 5.2.0 ([test run](https://github.com/yuvipanda/hubtraf/actions/runs/11424939017/job/31785956321?pr=49))
- tljh is erroring on tests with JupyterHub 5.2.0 though
  It seems that starting the server leads to 500 error:
  ```
  Debug: server-start fc621e8f6e9ca691 resp:<ClientResponse(http://localhost/hub/spawn) [500 Internal Server Error]>
  ```

## JupyterHub 5.2.0 logs on server spawn

```
Oct 20 08:35:05 9ce0cc64b132 python3[3068]: [I 2024-10-20 08:35:05.595 JupyterHub log:192] 302 POST /hub/login -> /hub/spawn (fc621e8f6e9ca691@127.0.0.1) 28.60ms
Oct 20 08:35:05 9ce0cc64b132 python3[3068]: [I 2024-10-20 08:35:05.621 JupyterHub provider:661] Creating oauth client jupyterhub-user-fc621e8f6e9ca691
Oct 20 08:35:05 9ce0cc64b132 useradd[3077]: new group: name=jupyter-fc621e8f6e9ca691, GID=1002
Oct 20 08:35:05 9ce0cc64b132 useradd[3077]: new user: name=jupyter-fc621e8f6e9ca691, UID=1000, GID=1002, home=/home/jupyter-fc621e8f6e9ca691, shell=/bin/sh, from=none
Oct 20 08:35:05 9ce0cc64b132 python3[3085]: Adding user jupyter-fc621e8f6e9ca691 to group jupyterhub-users
Oct 20 08:35:05 9ce0cc64b132 gpasswd[3085]: user jupyter-fc621e8f6e9ca691 added by root to group jupyterhub-users
Oct 20 08:35:05 9ce0cc64b132 python3[3068]: [E 2024-10-20 08:35:05.729 JupyterHub user:1007] Unhandled error starting fc621e8f6e9ca691's server: 'PATH'
Oct 20 08:35:05 9ce0cc64b132 python3[3068]:     Traceback (most recent call last):
Oct 20 08:35:05 9ce0cc64b132 python3[3068]:       File "/opt/tljh/hub/lib/python3.9/site-packages/jupyterhub/user.py", line 920, in spawn
Oct 20 08:35:05 9ce0cc64b132 python3[3068]:         await asyncio.wait_for(f, timeout=spawner.start_timeout)
Oct 20 08:35:05 9ce0cc64b132 python3[3068]:       File "/usr/lib/python3.9/asyncio/tasks.py", line 481, in wait_for
Oct 20 08:35:05 9ce0cc64b132 python3[3068]:         return fut.result()
Oct 20 08:35:05 9ce0cc64b132 python3[3068]:       File "/opt/tljh/hub/lib/python3.9/site-packages/systemdspawner/systemdspawner.py", line 288, in start
Oct 20 08:35:05 9ce0cc64b132 python3[3068]:         curpath=env["PATH"],
Oct 20 08:35:05 9ce0cc64b132 python3[3068]:     KeyError: 'PATH'
Oct 20 08:35:05 9ce0cc64b132 python3[3068]:     
Oct 20 08:35:05 9ce0cc64b132 python3[3068]: [E 2024-10-20 08:35:05.760 JupyterHub pages:312] Error starting server fc621e8f6e9ca691: 'PATH'
Oct 20 08:35:05 9ce0cc64b132 python3[3068]:     Traceback (most recent call last):
Oct 20 08:35:05 9ce0cc64b132 python3[3068]:     None: None
```

## Investigation

With https://github.com/jupyterhub/jupyterhub/pull/4904, the Spawner base class had its `env_keep` default value changed, to for example not include `PATH`. The default value of LocalProcessSpawner was unchanged, but SystemdSpawner used by tljh [inherits from Spawner](https://github.com/jupyterhub/systemdspawner/blob/45b06fefaf7751d2560da2bf60b9a34fbfe42f5a/systemdspawner/systemdspawner.py#L17), so it has been impacted.

I'm not confident on whats a sufficient fix yet, or where - it could be systemdspawner, tljh, or jupyterhub.

I think its systemdspawner to begin with, because I think its test suite would fail if `SystemdSpawner.extra_paths` where configured when used against jupyterhub 5.2.0, which it isn't in the test suite, but [extra_paths is configured by tljh](https://github.com/jupyterhub/the-littlest-jupyterhub/blob/d2b0fd2c6c111dcb346e4b61d000c0852148a769/tljh/jupyterhub_config.py#L28).

I've opened https://github.com/jupyterhub/systemdspawner/pull/144 so far about this, and have tried it in 2cb3bab.