### PR TITLE
Remove mention about beta state

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,6 @@ for information on the different ways of contributing to The Littlest JupyterHub
 See [this blog post](http://words.yuvi.in/post/the-littlest-jupyterhub/) for
 more information.
 
-## Development Status
-
-This project is currently in **beta** state. Folks have been using installations
-of TLJH for more than a year now to great success. While we try hard not to, we
-might still make breaking changes that have no clear upgrade pathway.
-
 ## Installation
 
 The Littlest JupyterHub (TLJH) can run on any server that is running at least

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,12 +4,6 @@ A simple [JupyterHub](https://github.com/jupyterhub/jupyterhub) distribution for
 a small (0-100) number of users on a single server. We recommend reading
 [](/topic/whentouse) to determine if this is the right tool for you.
 
-## Development Status
-
-This project is currently in **beta** state. Folks have been using installations
-of TLJH for more than a year now to great success. While we try hard not to, we
-might still make breaking changes that have no clear upgrade pathway.
-
 ## Installation
 
 The Littlest JupyterHub (TLJH) can run on any server that is running **Debian 11** or **Ubuntu 20.04** or **22.04** on an amd64 or arm64 CPU architecture.


### PR DESCRIPTION
We have a mention about TLJH being in a beta state, I think its better to not mention its development state now that we are making major releases with changelogs etc.