### PR TITLE
Fix `cpu` and `memory` config validation in JSON schema

### DIFF
--- a/docs/topic/tljh-config.md
+++ b/docs/topic/tljh-config.md
@@ -227,7 +227,7 @@ it after an argument like `remove-item` gives information about this specific co
 ```bash
 sudo tljh-config --help
 
-usage: tljh-config [-h] [--config-path CONFIG_PATH] {show,unset,set,add-item,remove-item,reload} ...
+usage: tljh-config [-h] [--config-path CONFIG_PATH] [--validate] [--no-validate] {show,unset,set,add-item,remove-item,reload} ...
 
 positional arguments:
   {show,unset,set,add-item,remove-item,reload}
@@ -238,10 +238,12 @@ positional arguments:
     remove-item         Remove a value from a list for a configuration property
     reload              Reload a component to apply configuration change
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   --config-path CONFIG_PATH
                         Path to TLJH config.yaml file
+  --validate            Validate the TLJH config
+  --no-validate         Do not validate the TLJH config
 ```
 
 ```bash

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -220,7 +220,8 @@ def test_cli_remove_int(tljh_dir):
         ("x", "x"),
         ("1x", "1x"),
         ("1.2x", "1.2x"),
-        (None, None),
+        ("None", None),
+        ("none", None),
         ("", ""),
     ],
 )

--- a/tljh/config.py
+++ b/tljh/config.py
@@ -317,8 +317,8 @@ def reload_component(component):
 
 def parse_value(value_str):
     """Parse a value string"""
-    if value_str is None:
-        return value_str
+    if value_str.lower() == "none":
+        return None
     if re.match(r"^\d+$", value_str):
         return int(value_str)
     elif re.match(r"^\d+\.\d*$", value_str):

--- a/tljh/config_schema.py
+++ b/tljh/config_schema.py
@@ -79,23 +79,16 @@ config_schema = {
             "description": "User CPU and memory limits.",
             "type": "object",
             "additionalProperties": False,
-            "properties": {"memory": {"type": "string"}, "cpu": {
-            "oneOf": [
-                {
-                  "type": "integer",
-                  "minimum": 0
+            "properties": {
+                "memory": {"type": "string"},
+                "cpu": {
+                    "anyOf": [
+                        {"type": "integer", "minimum": 0},
+                        {"type": "number", "minimum": 0},
+                        {"type": "string", "enum": ["None"]},
+                    ]
                 },
-                {
-                  "type": "number",
-                  "minimum": 0
-                },
-                {
-                  "type": "string",
-                  "enum": ["None"]
-                }
-            ]
-          }
-        },
+            },
         },
         "UserEnvironment": {
             "type": "object",

--- a/tljh/config_schema.py
+++ b/tljh/config_schema.py
@@ -83,7 +83,6 @@ config_schema = {
                 "memory": {"type": "string"},
                 "cpu": {
                     "anyOf": [
-                        {"type": "integer", "minimum": 0},
                         {"type": "number", "minimum": 0},
                         {"type": "string", "enum": ["None"]},
                     ]

--- a/tljh/config_schema.py
+++ b/tljh/config_schema.py
@@ -80,7 +80,12 @@ config_schema = {
             "type": "object",
             "additionalProperties": False,
             "properties": {
-                "memory": {"type": "string"},
+                "memory": {
+                    "anyOf": [
+                        {"type": "string"},
+                        {"type": "null"},
+                    ]
+                },
                 "cpu": {
                     "anyOf": [
                         {"type": "number", "minimum": 0},

--- a/tljh/config_schema.py
+++ b/tljh/config_schema.py
@@ -79,7 +79,23 @@ config_schema = {
             "description": "User CPU and memory limits.",
             "type": "object",
             "additionalProperties": False,
-            "properties": {"memory": {"type": "string"}, "cpu": {"type": "integer"}},
+            "properties": {"memory": {"type": "string"}, "cpu": {
+            "oneOf": [
+                {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                {
+                  "type": "number",
+                  "minimum": 0
+                },
+                {
+                  "type": "string",
+                  "enum": ["None"]
+                }
+            ]
+          }
+        },
         },
         "UserEnvironment": {
             "type": "object",

--- a/tljh/config_schema.py
+++ b/tljh/config_schema.py
@@ -84,7 +84,7 @@ config_schema = {
                 "cpu": {
                     "anyOf": [
                         {"type": "number", "minimum": 0},
-                        {"type": "string", "enum": ["None"]},
+                        {"type": "null"},
                     ]
                 },
             },


### PR DESCRIPTION
Fixes #1012. 

The config schema for `cpu` limits now accepts values such as `3`, `3.5` and `"None"`. Added `minimum`s of `0` to prevent negative numerics.

Details on `number` can be found in the [JSON Schema docs](https://json-schema.org/understanding-json-schema/reference/numeric). 