### PR TITLE
Set development env vars in dev documentation correctly

### DIFF
--- a/docs/contributing/dev-setup.md
+++ b/docs/contributing/dev-setup.md
@@ -24,6 +24,9 @@ The easiest & safest way to develop & test TLJH is with [Docker](https://www.doc
      --detach \
      --name=tljh-dev \
      --publish 12000:80 \
+     --env TLJH_BOOTSTRAP_DEV=yes \
+     --env TLJH_BOOTSTRAP_PIP_SPEC=/srv/src \
+     --env PATH=/opt/tljh/hub/bin:${PATH} \
      --mount type=bind,source="$(pwd)",target=/srv/src \
      tljh-systemd
    ```

--- a/integration-tests/Dockerfile
+++ b/integration-tests/Dockerfile
@@ -1,4 +1,4 @@
-# Systemd inside a Docker container, for CI only
+# Systemd inside a Docker container, for CI and local development
 ARG BASE_IMAGE=ubuntu:22.04
 FROM $BASE_IMAGE
 
@@ -27,10 +27,5 @@ RUN find /etc/systemd/system \
 RUN systemctl set-default multi-user.target
 
 STOPSIGNAL SIGRTMIN+3
-
-# Uncomment these lines for a development install
-# ENV TLJH_BOOTSTRAP_DEV=yes
-# ENV TLJH_BOOTSTRAP_PIP_SPEC=/srv/src
-# ENV PATH=/opt/tljh/hub/bin:${PATH}
 
 CMD ["/bin/bash", "-c", "exec /lib/systemd/systemd --log-target=journal 3>&1"]


### PR DESCRIPTION
Without this, the current dev setup documentation does not work.