### PR TITLE
Fix Ubuntu version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ more information.
 ## Installation
 
 The Littlest JupyterHub (TLJH) can run on any server that is running at least
-**Ubuntu 20.04**. Earlier versions of Ubuntu are not supported.
+**Ubuntu 22.04**. Earlier versions of Ubuntu are not supported.
 We have several tutorials to get you started.
 
 - Tutorials to create a new server from scratch on a cloud provider & run TLJH


### PR DESCRIPTION
It's out of date, as reported in https://discourse.jupyter.org/t/installation-of-tljh-on-ubuntu-20-04-does-not-work/32823