### PR TITLE
Fix `test_serverextensions` integration test

### DIFF
--- a/integration-tests/test_extensions.py
+++ b/integration-tests/test_extensions.py
@@ -9,11 +9,11 @@ def test_serverextensions():
     # jupyter-serverextension writes to stdout and stderr weirdly
     proc = subprocess.run(
         ["/opt/tljh/user/bin/jupyter-server", "extension", "list", "--sys-prefix"],
-        capture_output=True,
-        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
     )
 
-    output = proc.stdout + proc.stderr
+    output = proc.stdout.decode()
 
     extensions = [
         "jupyterlab",

--- a/integration-tests/test_extensions.py
+++ b/integration-tests/test_extensions.py
@@ -9,8 +9,11 @@ def test_serverextensions():
     # jupyter-serverextension writes to stdout and stderr weirdly
     proc = subprocess.run(
         ["/opt/tljh/user/bin/jupyter-server", "extension", "list", "--sys-prefix"],
-        stderr=subprocess.PIPE,
+        capture_output=True,
+        text=True,
     )
+
+    output = proc.stdout + proc.stderr
 
     extensions = [
         "jupyterlab",
@@ -19,7 +22,7 @@ def test_serverextensions():
     ]
 
     for e in extensions:
-        assert e in proc.stderr.decode()
+        assert e in output, f"'{e}' not found in server extensions: {output}"
 
 
 def test_labextensions():


### PR DESCRIPTION
Fix for integration test failures that seem to have started somewhat recently. See failures in #1024 and several recent `pre-commit autoupdate`s: https://github.com/jupyterhub/the-littlest-jupyterhub/actions/workflows/integration-test.yaml. 

Edit: see successful tests in my own fork: https://github.com/jrdnbradford/the-littlest-jupyterhub/actions/runs/13729823550