### PR TITLE
Add Temporary Authenticator documentation

### DIFF
--- a/docs/howto/auth/tmpauth.md
+++ b/docs/howto/auth/tmpauth.md
@@ -1,0 +1,63 @@
+(howto-auth-dummy)=
+
+# Authenticate users with temporary accounts automatically
+
+```{warning}
+The **Temporary Authenticator** lets _any_ user access JupyterHub without logging in.
+This authenticator is designed for open deployments and should be used with caution
+in environments where access control is important.
+```
+
+## Enabling the authenticator
+
+1. Install the TmpAuthenticator package:
+
+   ```bash
+   sudo pip3 install jupyterhub-tmpauthenticator
+   ```
+
+2. Enable the authenticator and configure it to allow all users:
+
+   ```bash
+   sudo tljh-config set auth.type tmpauthenticator.TmpAuthenticator
+   sudo tljh-config set auth.TmpAuthenticator.allow_all 'True'
+   ```
+
+3. Reload the configuration to apply changes:
+
+   ```bash
+   sudo tljh-config reload
+   ```
+
+## How it works
+
+The Temporary Authenticator:
+- Gives anyone who visits the JupyterHub landing page a user account without requiring login
+- Automatically spawns a single-user server for each visitor
+- Redirects users directly to their server without requiring them to click additional buttons
+
+This is particularly useful for temporary deployments, workshops, or demonstration environments where ease of access is more important than user authentication.
+
+## Configuration options
+
+While the default configuration works for most temporary deployments, you can customize the behavior:
+
+### Disabling automatic login
+
+By default, TmpAuthenticator automatically logs users in. You can change this behavior:
+
+```bash
+sudo tljh-config set auth.TmpAuthenticator.auto_login 'False'
+sudo tljh-config reload
+```
+
+With `auto_login` set to `False`, users will see a home page with a "Sign in" button.
+
+### Customizing the login button text
+
+If you've disabled automatic login, you can customize the text shown on the login button:
+
+```bash
+sudo tljh-config set auth.TmpAuthenticator.login_service 'Temporary Access'
+sudo tljh-config reload
+```

--- a/docs/howto/index.md
+++ b/docs/howto/index.md
@@ -36,6 +36,7 @@ with your JupyterHub. For more information on Authentication, see
 :titlesonly: true
 
 auth/dummy
+auth/tmpauth
 auth/github
 auth/google
 auth/awscognito


### PR DESCRIPTION
This adds another How-To chapter on how to set up tmpauthenticator.

In my experience wanting to set this up with existing docs, the configuration was not immediately obvious.
For example, in JupyterHub `Authenticator.allow_all` is false by default and I was getting error `Failed login for unknown user`. However, coming from working with JupyterHub config files, it was not clear how to set this up in TLJH. Turns out, you need

```
tljh-config set auth.TmpAuthenticator.allow_all 'True'
```

I hope this additional documentation is helpful and save someone half an hour of their time