### PR TITLE
Remove unit tests against Ubuntu 20.04 and Python 3.9

### DIFF
--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -40,9 +40,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: "Ubuntu 20.04, Py 3.9"
-            ubuntu_version: "20.04"
-            python_version: "3.9"
           - name: "Ubuntu 22.04, Py 3.10"
             ubuntu_version: "22.04"
             python_version: "3.10"


### PR DESCRIPTION
The Ubuntu 20.04 runner was removed starting with yesterday, resulting in https://github.com/jupyterhub/the-littlest-jupyterhub/actions/runs/14498147896/job/40671047108

I believe it makes sense to remove it.