### PR TITLE
Allows boostrap systemd check to pass if either `systemd` or `systemctl` are found

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -45,6 +45,9 @@ jobs:
           - name: "Ubuntu 24.04 Py 3.12"
             distro_image: "ubuntu:24.04"
             extra_flags: ""
+          - name: "Ubuntu 24.10 Py 3.12"
+            distro_image: "ubuntu:24.10"
+            extra_flags: ""
           - name: "Ubuntu 22.04, Py 3.10, from main"
             distro_image: "ubuntu:22.04"
             extra_flags: --upgrade-from=main

--- a/bootstrap/bootstrap.py
+++ b/bootstrap/bootstrap.py
@@ -204,6 +204,12 @@ def get_os_release_variable(key):
         .strip()
     )
 
+def host_has_systemd() -> bool:
+    if shutil.which("systemd"):
+        return True
+    if shutil.which("systemctl"):
+        return True
+    return False
 
 def ensure_host_system_can_install_tljh():
     """

--- a/bootstrap/bootstrap.py
+++ b/bootstrap/bootstrap.py
@@ -229,7 +229,7 @@ def ensure_host_system_can_install_tljh():
         sys.exit(1)
 
     # Require systemd (systemctl is a part of systemd)
-    if not shutil.which("systemd") or not shutil.which("systemctl"):
+    if not any([shutil.which("systemctl"), shutil.which("systemd")]):
         print("Systemd is required to run TLJH")
         # Provide additional information about running in docker containers
         if os.path.exists("/.dockerenv"):

--- a/bootstrap/bootstrap.py
+++ b/bootstrap/bootstrap.py
@@ -205,14 +205,6 @@ def get_os_release_variable(key):
     )
 
 
-def host_has_systemd() -> bool:
-    if shutil.which("systemd"):
-        return True
-    if shutil.which("systemctl"):
-        return True
-    return False
-
-
 def ensure_host_system_can_install_tljh():
     """
     Check if TLJH is installable in current host system and exit with a clear

--- a/bootstrap/bootstrap.py
+++ b/bootstrap/bootstrap.py
@@ -204,12 +204,14 @@ def get_os_release_variable(key):
         .strip()
     )
 
+
 def host_has_systemd() -> bool:
     if shutil.which("systemd"):
         return True
     if shutil.which("systemctl"):
         return True
     return False
+
 
 def ensure_host_system_can_install_tljh():
     """


### PR DESCRIPTION
Closes #1019.

## Test log

### Ubuntu 24.10 box with systemd installed

Correctly identifies the existence of `systemctl`.

```shell
daniel@dp-rb-jupyterhub:~$ cat /proc/version
Linux version 6.11.0-9-generic (buildd@lcy02-amd64-093) (x86_64-linux-gnu-gcc-14 (Ubuntu 14.2.0-4ubuntu2) 14.2.0, GNU ld (GNU Binutils for Ubuntu) 2.43.1) #9-Ubuntu SMP PREEMPT_DYNAMIC Mon Oct 14 13:19:59 UTC 2024
daniel@dp-rb-jupyterhub:~$ ./check_systemd_exists.test.py
INFO:tljh_test:testing systemd binary locator check	python=3.12.7 (main, Feb  4 2025, 14:46:03) [GCC 14.2.0]
INFO:tljh_test:found at least one of systemctl or systemd
INFO:tljh_test:/usr/bin/systemctl
INFO:tljh_test:None
```

### Darwin box with no systemd

Correctly identifies no systemd present.

```shell
> uname -a
Darwin johnny-mnemonic 24.4.0 Darwin Kernel Version 24.4.0: Fri Apr 11 18:33:40 PDT 2025; root:xnu-11417.101.15~117/RELEASE_ARM64_T6031 arm64 arm Darwin

the-littlest-jupyterhub on  djp-adjust-systemd-check [?] via 🐍 v3.12.4
> ./check_systemd_exists.test.py
INFO:tljh_test:testing systemd binary locator check	python=3.12.4 (main, Jul 25 2024, 22:11:22) [Clang 18.1.8 ]
ERROR:tljh_test:did not find either systemctl or systemd
```

## Test script used

Full test script for your reference:

```python
#!/usr/bin/env python3

import sys
import shutil
import logging

logger = logging.getLogger('tljh_test')
logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)


logger.info(f'testing systemd binary locator check\tpython={sys.version}')

if not any([shutil.which("systemctl"), shutil.which("systemd")]):
    logger.error("did not find either systemctl or systemd")
else:
    logger.info("found at least one of systemctl or systemd")
    logger.info(shutil.which("systemctl"))
    logger.info(shutil.which("systemd"))
```