### PR TITLE
Remove deprecated tests due to Ubuntu image changes

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -51,9 +51,6 @@ jobs:
           - name: "Ubuntu 22.04, Py 3.10, from latest"
             distro_image: "ubuntu:22.04"
             extra_flags: --upgrade-from=latest
-          - name: "Ubuntu 22.04, Py 3.10, from 0.2.0"
-            distro_image: "ubuntu:22.04"
-            extra_flags: --upgrade-from=0.2.0
           - name: "Ubuntu 22.04, Py 3.10, from 1.*"
             distro_image: "ubuntu:22.04"
             extra_flags: --upgrade-from=1

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -53,7 +53,7 @@ jobs:
         with:
           python-version: "${{ matrix.python_version }}"
 
-      - name: Install venv, git, pip and setup venv
+      - name: Install system dependencies and setup venv
         run: |
           export DEBIAN_FRONTEND=noninteractive
           apt-get update
@@ -61,7 +61,8 @@ jobs:
               python3-venv \
               python3-pip \
               bzip2 \
-              git
+              git \
+              curl
 
           python3 -m venv /srv/venv
           echo '/srv/venv/bin' >> $GITHUB_PATH

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -161,12 +161,6 @@ def _specifier(version):
                 "mamba": ">=1.1.0",
             },
         ),
-        # too-old Python (3.7), abort
-        (
-            "miniconda",
-            "4.7.10",
-            ValueError,
-        ),
     ],
 )
 def test_ensure_user_environment(


### PR DESCRIPTION
Fixes #1044. Fixes #1034. See discussion in those issues for details.

`curl` ended up being required for the `codecov-action` in the unit tests as well.