### PR TITLE
Use `pycurl` `.whl` for hub environment

### DIFF
--- a/tljh/requirements-hub-env.txt
+++ b/tljh/requirements-hub-env.txt
@@ -25,7 +25,4 @@ jupyterhub-idle-culler>=1.4.0,<2
 # ref: https://www.tornadoweb.org/en/stable/httpclient.html#module-tornado.simple_httpclient
 # ref: https://github.com/jupyterhub/the-littlest-jupyterhub/issues/289
 #
-# FIXME: pycurl is installed from source without its wheel for 7.45.3 has an
-#        issue reported in https://github.com/pycurl/pycurl/issues/834.
-#
-pycurl>=7.45.3,<8 --no-binary=pycurl
+pycurl>=7.45.7,<8


### PR DESCRIPTION
Use of `--no-binary` was required for `pycurl` `7.45.3` due to a wheel problem. Related issues:

- https://github.com/jupyterhub/oauthenticator/issues/731
- https://github.com/jupyterhub/the-littlest-jupyterhub/issues/964
- https://github.com/pycurl/pycurl/issues/834

As of `7.45.4` this was corrected, installing the latest `pycurl` from the wheel now works. This saves a non-negligible amount of time in CI actions, tests, and installation.