### PR TITLE
Update systemd.md with clearer override instructions

### DIFF
--- a/docs/howto/admin/systemd.md
+++ b/docs/howto/admin/systemd.md
@@ -73,7 +73,7 @@ The output should look like the following:
 :alt: Checking the status of the JupyterHub systemd service
 ```
 
-To override the `traefik` settings, create a new file under `/etc/systemd/system/traefik.service.d/override.conf` 
+To override the `traefik` settings, create a new file under `/etc/systemd/system/traefik.service.d/override.conf`
 (or use `sudo systemctl edit traefik.service`) and follow the same steps.
 
 ## References


### PR DESCRIPTION
Clarify instructions for overriding traefik settings.

SystemD has inbuilt ways to *create* the override files without users having to create the files themselves.

To that end, just using `sudo systemctl edit [SERVICENAME].service` will work to create the service's override files.