### PR TITLE
Add plausible stats tracking, consolidated with jupyter.org stats

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -139,9 +139,12 @@ rediraffe_redirects = {
     "howto/env/server-resources": "howto/user-env/server-resources",
 }
 
+
 def setup(app):
     # Enable Plausible.io stats
-    app.add_js_file("https://plausible.io/js/pa-B75UO5--FNXYQSG7GBWkf.js", loading_method="async")
+    app.add_js_file(
+        "https://plausible.io/js/pa-B75UO5--FNXYQSG7GBWkf.js", loading_method="async"
+    )
     app.add_js_file(
         filename=None,
         body="window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};plausible.init({hashBasedRouting:true})",


### PR DESCRIPTION
I noticed that these docs are served from jupyter.org. This adds plausible stats tracking, consolidated with jupyter.org stats. This PR is similar to https://github.com/jupyter/jupyter/pull/797. Stats would show up at https://plausible.io/jupyter.org
