### PR TITLE
Enclose ${PATH} in double-quotes

### DIFF
--- a/docs/contributing/dev-setup.md
+++ b/docs/contributing/dev-setup.md
@@ -26,7 +26,7 @@ The easiest & safest way to develop & test TLJH is with [Docker](https://www.doc
      --publish 12000:80 \
      --env TLJH_BOOTSTRAP_DEV=yes \
      --env TLJH_BOOTSTRAP_PIP_SPEC=/srv/src \
-     --env PATH=/opt/tljh/hub/bin:${PATH} \
+     --env "PATH=/opt/tljh/hub/bin:${PATH}" \
      --mount type=bind,source="$(pwd)",target=/srv/src \
      tljh-systemd
    ```


### PR DESCRIPTION
Closes https://github.com/jupyterhub/the-littlest-jupyterhub/issues/1054

I will merge this without waiting for a review given the change is small and in the documentation.