### PR TITLE
Update `traefik` to `3.6.5` 

### DIFF
--- a/tljh/traefik.py
+++ b/tljh/traefik.py
@@ -29,13 +29,13 @@ else:
     plat = None
 
 # Traefik releases: https://github.com/traefik/traefik/releases
-traefik_version = "3.1.4"
+traefik_version = "3.6.5"
 
 # record sha256 hashes for supported platforms here
 # checksums are published in the checksums.txt of each release
 checksums = {
-    "linux_amd64": "eb7227b1b235195355904839c514a9ed6a0aecdcf5dab02ad48db21b05c5e700",
-    "linux_arm64": "e5d970a7f11267b70a8e308cb80f859bba4f420f24789f7393fdf3f4cd031631",
+    "linux_amd64": "a9d891026496e0e16cbe4e0599339487411c9876246238c06bbe1a532350a096",
+    "linux_arm64": "801449a26d1389aa60bbb96e79a8ecc8c385b2e76b1dcaf487fd712c427b2831",
 }
 
 _tljh_path = Path(__file__).parent.resolve()


### PR DESCRIPTION
Closes #1058. All tests are passing in my fork, and after a quick check I couldn't find anything in the [Traefik migration documentation](https://doc.traefik.io/traefik/v3.6/migrate/v3/) that requires changes.