### PR TITLE
docs(auth): add change-password endpoint to NativeAuthenticator guide

### DIFF
--- a/docs/howto/auth/nativeauth.md
+++ b/docs/howto/auth/nativeauth.md
@@ -40,6 +40,11 @@ tljh-config set auth.NativeAuthenticator.open_signup true
 tljh-config reload
 ```
 
+## Users changing their own password
+
+Users can change their password after logging in by visiting:
+`<your_server_ip>/hub/auth/change-password`.
+
 ## Optional features
 
 More optional features are available on the [authenticator documentation](https://native-authenticator.readthedocs.io/en/latest/)


### PR DESCRIPTION
## Summary
Adds documentation for the user-facing password change endpoint when using NativeAuthenticator.

## Changes
- Added a new section in `docs/howto/auth/nativeauth.md`:
  - `Users changing their own password`
  - points to `<your_server_ip>/hub/auth/change-password`

## Why
Issue #523 notes that this endpoint should be documented for both FirstUseAuthenticator and NativeAuthenticator.

Closes #523.
