### PR TITLE
Consolidate supported operating systems in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ more information.
 
 ## Installation
 
-The Littlest JupyterHub (TLJH) can run on any server that is running **Debian** version **11**, **12**, or **13**, or **Ubuntu** version **22.04** or **24.04** on an amd64 or arm64 CPU architecture.
-Earlier versions of Ubuntu and Debian are not supported.
+The Littlest JupyterHub (TLJH) aims to support Debian and Ubuntu versions that have current Long-Term Support (LTS), on amd64 or arm64 CPU architectures.
+Other Linux distributions are not supported.
 We have several tutorials to get you started.
 
 - Tutorials to create a new server from scratch on a cloud provider & run TLJH

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,10 +6,7 @@ a small (0-100) number of users on a single server. We recommend reading
 
 ## Installation
 
-The Littlest JupyterHub (TLJH) can run on any server that is running **Debian** version **11**, **12**, or **13**, or **Ubuntu** version **22.04** or **24.04** on an amd64 or arm64 CPU architecture.
-We aim to support 'stable' and Long-Term Support (LTS) versions.
-Newer versions are likely to work with little or no adjustment, but these are not officially supported or tested.
-Earlier versions of Ubuntu and Debian are not supported, nor are other Linux distributions.
+See [supported operating systems](supported-os) for the distributions and versions TLJH runs on.
 We have a bunch of tutorials to get you started.
 
 - Tutorials to create a new server from scratch on a cloud provider & run TLJH

--- a/docs/install/custom-server.md
+++ b/docs/install/custom-server.md
@@ -26,7 +26,7 @@ a server you have access to.
 ## Pre-requisites
 
 1. Some familiarity with the command line.
-2. A server running Debian 11+ or Ubuntu 22.04+ where you have root access.
+2. A server with [a supported operating system](supported-os) and root access.
 3. At least **1GB** of RAM on your server.
 4. Ability to `ssh` into the server & run commands from the prompt.
 5. An **IP address** where the server can be reached from the browsers of your target audience.

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -2,8 +2,7 @@
 
 # Installing
 
-The Littlest JupyterHub (TLJH) can run on any server that is running **Debian** version **11**, **12**, or **13**, or **Ubuntu** version **22.04** or **24.04** on an amd64 or arm64 CPU architecture.
-Earlier versions of Ubuntu and Debian are not supported, nor are other Linux distributions.
+See [supported operating systems](supported-os) for the distributions and versions TLJH runs on.
 We have a bunch of tutorials to get you started.
 
 Tutorials to create a new server from scratch on a cloud provider & run TLJH

--- a/docs/topic/requirements.md
+++ b/docs/topic/requirements.md
@@ -2,9 +2,12 @@
 
 # Server Requirements
 
+(supported-os)=
+
 ## Operating System
 
-We require Debian 11+ or Ubuntu 22.04+ as the base operating system for your server.
+The Littlest JupyterHub (TLJH) aims to support Debian and Ubuntu versions that have current Long-Term Support (LTS), on amd64 or arm64 CPU architectures.
+Other Linux distributions are not supported.
 
 ## Root access
 


### PR DESCRIPTION
Based on a suggestion by @minrk in #1069.

Might be room for improvements here, but this is certainly better than the current documentation that can get stale easily.

The main OS requirements are described generally in `docs/topic/requirements.md`, with links to that heading where necessary.